### PR TITLE
Add Showcase and Showfolio themes

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -2,6 +2,8 @@ github.com/2-REC/hugo-myportfolio-theme
 github.com/AlexFinn/simple-a
 github.com/AmazingRise/hugo-theme-diary
 github.com/AngeloStavrow/indigo
+github.com/apvarun/showcase-hugo-theme
+github.com/apvarun/showfolio-hugo-theme
 github.com/Chen-Zhe/photo-grid
 github.com/EmielH/hallo-hugo
 github.com/EmielH/stip-hugo


### PR DESCRIPTION
* Showcase theme was missing after last update in the theme site.
* Showfolio is a new theme which was submitted a few months back to the old repository

