### PR TITLE
Added hugo tufte

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -395,3 +395,4 @@ gitlab.com/mertbakir/resume-a4
 gitlab.com/rmaguiar/hugo-theme-color-your-world
 gitlab.com/tmuguet/hugo-split-gallery
 gitlab.com/toryanderson/hugo-icarus
+github.com/slashformotion/hugo-tufte


### PR DESCRIPTION
I am the new maintainer of the theme hugo-tufte. 

The original theme can be found [here](https://github.com/shawnohare/hugo-tufte). It is "largely unmaintained" as the original author (@shawnohare) said.