### PR TITLE
Add Vibrant Shadows theme by Softorage to the list

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -32,6 +32,7 @@ github.com/RCJacH/hugo-webslides
 github.com/RainerChiang/simpleness
 github.com/RealOrangeOne/hugo-theme-revealjs
 github.com/SAGGameDeveloper/hugo-minimalist-spa
+github.com/Softorage/HugoTheme-VibrantShadows
 github.com/Somrat37/somrat
 github.com/StaticMania/portio-hugo
 github.com/StaticMania/roxo-hugo


### PR DESCRIPTION
Vibrant Shadows theme has been updated to fix issue Softorage/HugoTheme-VibrantShadows#3. This PR is as per issue gohugoio/hugoThemesSiteBuilder#53.