### PR TITLE
Update 2 themes to correct repo URL

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -97,8 +97,8 @@ github.com/cowboysmall-tools/hugo-business-frontpage-theme
 github.com/cowboysmall-tools/hugo-devresume-theme
 github.com/cristianmarint/sicily-hugo-theme
 github.com/cssandstuff/hugo-theme-winning
-github.com/curttimson/hugo-theme-dopetrope
-github.com/curttimson/hugo-theme-massively
+github.com/curtiscde/hugo-theme-dopetrope
+github.com/curtiscde/hugo-theme-massively
 github.com/d-kusk/minimage
 github.com/damiencaselli/hugo-journal
 github.com/damiencaselli/paperback


### PR DESCRIPTION
2 of the themes are referencing an outdated repository URL.

This PR updates these URLs to the correct location.