### PR TITLE
fix vno-hugo missing image

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -384,7 +384,7 @@ github.com/xaprb/story
 github.com/xaviablaza/hugo-lodi-theme
 github.com/xianmin/hugo-theme-jane
 github.com/xiaoheiAh/hugo-theme-pure
-# Missing image github.com/xslingcn/vno-hugo
+github.com/xslingcn/vno-hugo
 github.com/yanlinlin82/simple-style
 github.com/yihui/hugo-xmag
 github.com/yihui/hugo-xmin


### PR DESCRIPTION
I think it's been fixed in https://github.com/xslingcn/Vno-Hugo/commit/15075b625774f8c70e2decae8465920a30e0abb9.