### PR TITLE
Remove Hugo Future Imperfect Slim theme

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -269,7 +269,6 @@ github.com/onweru/newsroom
 github.com/opera7133/Blonde
 github.com/opera7133/tella
 github.com/orf/bare-hugo-theme
-github.com/pacollins/hugo-future-imperfect-slim
 github.com/panr/hugo-theme-hello-friend
 github.com/panr/hugo-theme-terminal
 github.com/parsiya/Hugo-Octopress


### PR DESCRIPTION
I am no longer maintaining this theme, so I am removing it from the theme site.