### PR TITLE
Remove github.com/htdvisser/hugo-base16-theme

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -168,7 +168,6 @@ github.com/hdcdstr8fwd/foundation-theme
 github.com/heyeshuang/hugo-theme-tokiwa
 github.com/hivickylai/hugo-theme-sam
 github.com/hossainemruz/toha
-github.com/htdvisser/hugo-base16-theme
 github.com/htr3n/hyde-hyde
 github.com/humrochagf/colordrop
 github.com/huyb1991/hugo-lamp


### PR DESCRIPTION
I am no longer maintaining my theme [github.com/htdvisser/hugo-base16-theme](https://github.com/htdvisser/hugo-base16-theme), so I think it's best to remove it from the theme site.