### PR TITLE
Add Simplecss Hugo theme

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -319,6 +319,7 @@ github.com/spech66/bootstrap-bp-hugo-theme
 github.com/spech66/flex-bp-hugo-cv
 github.com/spech66/materialize-bp-hugo-theme
 github.com/spf13/hyde
+github.com/splch/hugo-simplecss
 github.com/spookey/slick
 github.com/st-wong/hugo-spectre-pixel-theme
 github.com/sudorook/capsule


### PR DESCRIPTION
# Hugo Theme for [Simple.css](https://simplecss.org/)

![Lines of code](https://img.shields.io/tokei/lines/github/splch/hugo-simplecss)

This theme is a bare minimum theme for Hugo. It uses no JavaScript, tracking, or other external resources. The styling is handled via a submodule of [Simple.css](https://github.com/kevquirk/simple.css/).

## Demo

My blog uses this theme: <https://slc.is/>
