### PR TITLE
fix(themes.txt): raise osprey-delight to v5

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -177,7 +177,7 @@ github.com/KatamariJr/split-landing
 github.com/kaushalmodi/hugo-bare-min-theme
 github.com/kc0bfv/autophugo
 github.com/kc0bfv/ticky_tacky_dark
-github.com/kdevo/osprey-delight
+github.com/kdevo/osprey-delight/v5
 github.com/keichi/vienna
 github.com/khusika/FeelIt
 github.com/kimcc/hugo-theme-noteworthy


### PR DESCRIPTION
Due to a [large update](https://github.com/kdevo/osprey-delight/releases/tag/v5.0.0) and the switch to Hugo modules, the major version has been increased. 
Therefore, the import path has to be changed in order to display the newest version of Osprey Delight on the Hugo themes site.

Thanks for the awesome Hugo and the maintenance of this repository!