### PR TITLE
Fix theme name extraction from theme path when it ends with the version number

### DIFF
--- a/pkg/buildcmd/build.go
+++ b/pkg/buildcmd/build.go
@@ -169,8 +169,8 @@ func (c *buildClient) writeThemesContent() error {
 }
 
 func (c *buildClient) writeThemeContent(k string, m client.Module) error {
-  re := regexp.MustCompile(`\/v\d+$`)
-  themeName := strings.ToLower(path.Base(re.ReplaceAllString(k, "")))
+        re := regexp.MustCompile(`\/v\d+$`)
+        themeName := strings.ToLower(path.Base(re.ReplaceAllString(k, "")))
 
 	themeDir := filepath.Join(c.contentDir, "themes", themeName)
 	client.CheckErr(os.MkdirAll(themeDir, 0777))

--- a/pkg/buildcmd/build.go
+++ b/pkg/buildcmd/build.go
@@ -169,7 +169,8 @@ func (c *buildClient) writeThemesContent() error {
 }
 
 func (c *buildClient) writeThemeContent(k string, m client.Module) error {
-	themeName := strings.ToLower(path.Base(k))
+  re := regexp.MustCompile(`\/v\d+$`)
+  themeName := strings.ToLower(path.Base(re.ReplaceAllString(k, "")))
 
 	themeDir := filepath.Join(c.contentDir, "themes", themeName)
 	client.CheckErr(os.MkdirAll(themeDir, 0777))


### PR DESCRIPTION
If I understand correctly, the theme path that is added to the `themes.txt` file should match the theme path in the corresponding `go.mod` file if the theme in question supports Hugo modules. So, for example, the `themes.txt` file contains the following path: `github.com/kdevo/osprey-delight/v5`, which matches the module's value in this [go.mod](https://github.com/kdevo/osprey-delight/blob/master/go.mod) file. 

But when we check this theme on [themes.gohugo.io](https://themes.gohugo.io/themes/), its content page is available under this URL: https://themes.gohugo.io/themes/v5/, which is not correct. Instead, the URL should be https://themes.gohugo.io/themes/osprey-delight.

Therefore, the proposed PR aims to fix the issue with extracting the theme name when the theme path ends with the version number part.