### PR TITLE
Update theme path for the Bilberry Hugo theme

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -189,7 +189,7 @@ github.com/koirand/pulp
 github.com/kongdivin/hugo-theme-okayish-blog
 github.com/kritoke/darksimplicity
 github.com/lasseborly/anybodyhome
-github.com/Lednerb/bilberry-hugo-theme
+github.com/Lednerb/bilberry-hugo-theme/v3
 github.com/leonardofaria/bento
 github.com/leonhe/hugo_eiio
 github.com/leonstafford/accessible-minimalism-hugo-theme


### PR DESCRIPTION
Since the issue with extracting the theme name was fixed, I would like to update the theme path for the Bilberry Hugo theme.