### PR TITLE
add termishTheme

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -400,3 +400,4 @@ gitlab.com/rmaguiar/hugo-theme-color-your-world
 gitlab.com/tmuguet/hugo-split-gallery
 gitlab.com/toryanderson/hugo-icarus
 gitlab.com/VincentTam/huginn
+github.com/yilkalargaw/termishTheme


### PR DESCRIPTION
A theme intended to look like a text editor(Emacs) with support for dark mode, KaTeX and highlight.js. It also works well with javascript disabled.