### PR TITLE
Add 10 themes from the PR back log

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -16,6 +16,7 @@ github.com/alex-shpak/hugo-book
 github.com/alexandrevicenzi/soho
 github.com/AlexFinn/simple-a
 github.com/allnightgrocery/hugo-theme-blueberry-detox
+github.com/alloydwhitlock/huey
 github.com/AmazingRise/hugo-theme-diary
 github.com/AngeloStavrow/indigo
 github.com/antonpolishko/hugo-stellar-theme
@@ -30,18 +31,22 @@ github.com/azmelanar/hugo-theme-pixyll
 github.com/bake/solar-theme-hugo
 github.com/balaramadurai/hugo-travelify-theme
 github.com/bep/docuapi/v2
+github.com/Binary-Eater/hugo-theme-ghci
 github.com/bjacquemet/personal-web
 github.com/blankoworld/hugo_theme_adam_eve
+github.com/Bonzdev/alexa-portfolio
 github.com/brycematheson/allegiant
 github.com/bul-ikana/hugo-cards
 github.com/CaiJimmy/hugo-theme-stack
 github.com/calintat/minimal
+github.com/canstand/compost
 github.com/capnfabs/paperesque
 github.com/caressofsteel/hugo-story
 github.com/carsonip/hugo-theme-minos
 github.com/cboettig/hugo-now-ui
 github.com/cdeck3r/OneDly-Theme
 github.com/cfrome77/hugo-theme-sky
+github.com/chaitanya4vedi/navada
 github.com/chipsenkbeil/grid-side
 github.com/chipzoller/hugo-clarity
 github.com/chollinger93/ink-free
@@ -54,6 +59,7 @@ github.com/cristianmarint/sicily-hugo-theme
 github.com/cssandstuff/hugo-theme-winning
 github.com/curtiscde/hugo-theme-dopetrope
 github.com/curtiscde/hugo-theme-massively
+github.com/cyevgeniy/monday-theme
 github.com/d-kusk/minimage
 github.com/damiencaselli/hugo-journal
 github.com/damiencaselli/paperback
@@ -103,6 +109,7 @@ github.com/funkydan2/hugo-kiera
 github.com/g1eny0ung/hugo-theme-dream
 github.com/gangjun06/SimpleIntro
 github.com/garvincasimir/hugo-h5bp-simple
+github.com/gcaracuel/hugo-theme-gutenberg
 github.com/GDGToulouse/devfest-theme-hugo
 github.com/geschke/hugo-tikva
 github.com/gesquive/slate
@@ -277,6 +284,7 @@ github.com/rhnvrm/bodhi
 github.com/ribice/kiss
 github.com/rijoth/rsimple
 github.com/rmsubekti/the-roots-home
+github.com/RononDex/interstellar-hugo
 github.com/runningstream/hugograyscale
 github.com/rz3n/hugo-theme-freshstart
 github.com/s4n7h0/hugo-theme-timeline
@@ -390,6 +398,7 @@ github.com/zzossig/hugo-theme-zdoc
 github.com/zzossig/hugo-theme-zzo
 github.com/zzzmisa/hugo-theme-doors
 gitlab.com/avron/gruvhugo
+gitlab.com/gabmus/hugo-ficurinia
 gitlab.com/ian-s-mcb/smigle-hugo-theme
 gitlab.com/kskarthik/monopriv
 gitlab.com/kskarthik/resto-hugo


### PR DESCRIPTION
Starting at the end of the PR list.

Sorry for the delay :-)

* github.com/Bonzdev/alexa-portfolio
* gitlab.com/gabmus/hugo-ficurinia
* github.com/chaitanya4vedi/navada
* github.com/alloydwhitlock/huey
* github.com/Binary-Eater/hugo-theme-ghci
* github.com/hugo-fixit/FixIt
* github.com/gcaracuel/hugo-theme-gutenberg
* github.com/RononDex/interstellar-hugo
* github.com/canstand/compost
* github.com/cyevgeniy/monday-theme

Closes #96
Closes #102
Closes #103
Closes #106
Closes #107
Closes #109
Closes #110
Closes #113
Closes #115
Closes #117
