### PR TITLE
Add `v3` to hugo-theme-stack path

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -43,7 +43,7 @@ github.com/Bonzdev/alexa-portfolio
 github.com/boratanrikulu/eternity
 github.com/brycematheson/allegiant
 github.com/bul-ikana/hugo-cards
-github.com/CaiJimmy/hugo-theme-stack
+github.com/CaiJimmy/hugo-theme-stack/v3
 github.com/calintat/minimal
 github.com/canstand/compost
 github.com/capnfabs/paperesque


### PR DESCRIPTION
Currently, it fetches the v2 version's source code, and URLs like `demosite` are outdated.