### PR TITLE
:new: :art: themes: Add UNICEF Inventory theme

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -382,6 +382,7 @@ github.com/tylerjlawson/simple-snipcart-shop
 github.com/uicardiodev/hugo-lime
 github.com/uicardiodev/hugo-sodium-theme
 github.com/uicardiodev/hugo-uilite
+github.com/unicef/inventory-hugo-theme
 github.com/uPagge/uBlogger
 github.com/urjaacharya/redgood
 github.com/vaga/hugo-theme-m10c
@@ -414,7 +415,7 @@ github.com/Y4er/hugo-theme-easybook
 github.com/yanlinlin82/simple-style
 github.com/yihui/hugo-xmag
 github.com/yihui/hugo-xmin
-github.com/yilkalargaw/termishTheme 
+github.com/yilkalargaw/termishTheme
 github.com/yoshiharuyamashita/blackburn
 github.com/your-identity/hugo-theme-dimension
 github.com/yue1124/hero


### PR DESCRIPTION
This commit adds a new entry for the UNICEF Inventory theme, used for a knowledge-base static site for knowledge-transfer use cases at the UNICEF Office of Innovation.