### PR TITLE
Remove deleted theme

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -214,7 +214,6 @@ github.com/kishaningithub/hugo-shopping-product-catalogue-simple
 github.com/knadh/hugo-ink
 github.com/knokmki612/hugo-fill-and-stroke
 github.com/koirand/pulp
-github.com/kongdivin/hugo-theme-okayish-blog
 github.com/kritoke/darksimplicity
 github.com/lasseborly/anybodyhome
 github.com/leafee98/hugo-theme-flat


### PR DESCRIPTION
https://github.com/kongdivin/hugo-theme-okayish-blog no longer exists.

It's causing the update-themes action to fail.