### PR TITLE
Update owner of hugo-fresh theme

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -236,7 +236,6 @@ github.com/LordMathis/hugo-theme-nightfall
 github.com/LordMathis/hugo-theme-nix
 github.com/loveminimal/hugo-theme-virgo
 github.com/lubang/hugo-hello-programmer-theme
-github.com/lucperkins/hugo-fresh
 github.com/luizdepra/hugo-coder
 github.com/LukasJoswiak/etch
 github.com/lukeorth/poison
@@ -372,6 +371,7 @@ github.com/st-wong/hugo-spectre-pixel-theme
 github.com/StaticMania/portio-hugo
 github.com/StaticMania/roxo-hugo
 github.com/SteveLane/hugo-icon
+github.com/StefMa/hugo-fresh
 github.com/sudorook/capsule
 github.com/surajmandalcell/potato-dark
 github.com/syui/hugo-theme-air


### PR DESCRIPTION
In 2019 I took over the hugo-fresh theme from @lucperkins
He transfered the project to me.

Last week I changed the theme to an hugo module only theme. So submodule are not working anymore.

It seems that modules are more strict and do not follow redirects by default.
Therefore the [GH actions](https://github.com/gohugoio/hugoThemesSiteBuilder/actions/runs/4421424755/jobs/7752204604) where failing.

I guess this change will fix it 🤞 