### PR TITLE
ci: bump actions/checkout from v2 to v3

### DIFF
--- a/.github/workflows/update-themes.yml
+++ b/.github/workflows/update-themes.yml
@@ -9,7 +9,7 @@ jobs:
     env:
       HUGO_CACHEDIR: /tmp/hugo_cache
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: "^1.19.5"

--- a/cmd/hugothemesitebuilder/build/cache/0000.githubrepos.json
+++ b/cmd/hugothemesitebuilder/build/cache/0000.githubrepos.json
@@ -29,11 +29,11 @@
   "github.com/4s3ti/hugo-theme-hello-4s3ti": {
     "id": 492198943,
     "created_at": "2022-05-14T11:39:58Z",
-    "updated_at": "2023-02-21T13:22:29Z",
+    "updated_at": "2023-03-28T22:03:16Z",
     "name": "hugo-theme-hello-4s3ti",
     "description": "Pretty basic theme for Hugo that covers all of the essentials. All you have to do is start typing!",
     "html_url": "https://github.com/4s3ti/hugo-theme-hello-4s3ti",
-    "stargazers_count": 3
+    "stargazers_count": 4
   },
   "github.com/4s3ti/terminalcv": {
     "id": 495062258,
@@ -47,11 +47,11 @@
   "github.com/526avijitgupta/gokarna": {
     "id": 369759352,
     "created_at": "2021-05-22T08:45:30Z",
-    "updated_at": "2023-03-19T19:54:40Z",
+    "updated_at": "2023-03-27T07:26:01Z",
     "name": "gokarna",
     "description": "A minimal opinionated theme for Hugo",
     "html_url": "https://github.com/526avijitgupta/gokarna",
-    "stargazers_count": 165
+    "stargazers_count": 168
   },
   "github.com/7ma7X/HugoTeX": {
     "id": 268434902,
@@ -119,11 +119,11 @@
   "github.com/CaiJimmy/hugo-theme-stack/v3": {
     "id": 289457038,
     "created_at": "2020-08-22T09:16:55Z",
-    "updated_at": "2023-03-25T17:45:52Z",
+    "updated_at": "2023-03-29T11:24:36Z",
     "name": "hugo-theme-stack",
     "description": "Card-style Hugo theme designed for bloggers",
     "html_url": "https://github.com/CaiJimmy/hugo-theme-stack",
-    "stargazers_count": 3118
+    "stargazers_count": 3133
   },
   "github.com/EmielH/hallo-hugo": {
     "id": 155071757,
@@ -191,20 +191,20 @@
   "github.com/HEIGE-PCloud/DoIt": {
     "id": 358233149,
     "created_at": "2021-04-15T11:24:30Z",
-    "updated_at": "2023-03-25T09:14:45Z",
+    "updated_at": "2023-03-29T11:42:36Z",
     "name": "DoIt",
     "description": "A clean, elegant and advanced blog theme for Hugo.",
     "html_url": "https://github.com/HEIGE-PCloud/DoIt",
-    "stargazers_count": 432
+    "stargazers_count": 436
   },
   "github.com/Ice-Hazymoon/hugo-theme-luna": {
     "id": 486781027,
     "created_at": "2022-04-28T23:48:19Z",
-    "updated_at": "2023-03-18T08:15:42Z",
+    "updated_at": "2023-03-27T09:49:15Z",
     "name": "hugo-theme-luna",
     "description": "A simple, performance-first, SEO-friendly Hugo theme / 一个轻量，快速，SEO 友好的 Hugo 主题",
     "html_url": "https://github.com/Ice-Hazymoon/hugo-theme-luna",
-    "stargazers_count": 223
+    "stargazers_count": 224
   },
   "github.com/IvanChou/hugo-theme-vec": {
     "id": 67712359,
@@ -254,11 +254,11 @@
   "github.com/KatamariJr/split-landing": {
     "id": 384190570,
     "created_at": "2021-07-08T16:46:07Z",
-    "updated_at": "2022-10-14T10:20:06Z",
+    "updated_at": "2023-03-29T07:49:07Z",
     "name": "split-landing",
     "description": "A landing page theme made for Hugo",
     "html_url": "https://github.com/KatamariJr/split-landing",
-    "stargazers_count": 3
+    "stargazers_count": 4
   },
   "github.com/Lednerb/bilberry-hugo-theme/v3": {
     "id": 108488686,
@@ -290,11 +290,11 @@
   "github.com/LukasJoswiak/etch": {
     "id": 264117296,
     "created_at": "2020-05-15T06:42:30Z",
-    "updated_at": "2023-03-17T07:04:07Z",
+    "updated_at": "2023-03-29T12:18:13Z",
     "name": "etch",
     "description": "A simple, responsive writing theme for Hugo.",
     "html_url": "https://github.com/LukasJoswiak/etch",
-    "stargazers_count": 243
+    "stargazers_count": 244
   },
   "github.com/M1cR0xf7/kaslaanka": {
     "id": 440512474,
@@ -326,16 +326,16 @@
   "github.com/McShelby/hugo-theme-relearn": {
     "id": 295128524,
     "created_at": "2020-09-13T10:34:08Z",
-    "updated_at": "2023-03-21T18:46:18Z",
+    "updated_at": "2023-03-26T15:24:15Z",
     "name": "hugo-theme-relearn",
     "description": "A theme for Hugo designed for documentation",
     "html_url": "https://github.com/McShelby/hugo-theme-relearn",
-    "stargazers_count": 165
+    "stargazers_count": 166
   },
   "github.com/MeiK2333/github-style": {
     "id": 216473473,
     "created_at": "2019-10-21T03:53:00Z",
-    "updated_at": "2023-03-25T07:58:31Z",
+    "updated_at": "2023-03-29T13:08:50Z",
     "name": "github-style",
     "description": "",
     "html_url": "https://github.com/MeiK2333/github-style",
@@ -344,11 +344,11 @@
   "github.com/Mitrichius/hugo-theme-anubis": {
     "id": 233350753,
     "created_at": "2020-01-12T06:48:55Z",
-    "updated_at": "2023-03-19T08:24:29Z",
+    "updated_at": "2023-03-26T04:48:30Z",
     "name": "hugo-theme-anubis",
     "description": "Anubis is a simple minimalist theme for Hugo blog engine",
     "html_url": "https://github.com/Mitrichius/hugo-theme-anubis",
-    "stargazers_count": 327
+    "stargazers_count": 328
   },
   "github.com/Morgscode/hugo-theme-spaced-blog": {
     "id": 595376431,
@@ -461,29 +461,29 @@
   "github.com/StaticMania/portio-hugo": {
     "id": 290140349,
     "created_at": "2020-08-25T07:05:28Z",
-    "updated_at": "2023-03-25T06:35:39Z",
+    "updated_at": "2023-03-27T21:04:58Z",
     "name": "portio-hugo",
     "description": "Portio Hugo is a simple, minimal and responsive Portfolio Hugo Theme. Portio Hugo is well organized, well-formatted, and named accordingly so it’s easy to change any and all of the design. Portio is built with Bootstrap 4. You can customize it very easily to fit your needs.",
     "html_url": "https://github.com/StaticMania/portio-hugo",
-    "stargazers_count": 376
+    "stargazers_count": 378
   },
   "github.com/StaticMania/roxo-hugo": {
     "id": 245805105,
     "created_at": "2020-03-08T11:52:08Z",
-    "updated_at": "2023-03-24T08:46:13Z",
+    "updated_at": "2023-03-28T01:05:47Z",
     "name": "roxo-hugo",
     "description": "",
     "html_url": "https://github.com/StaticMania/roxo-hugo",
-    "stargazers_count": 129
+    "stargazers_count": 130
   },
   "github.com/StefMa/hugo-fresh": {
     "id": 128991512,
     "created_at": "2018-04-10T20:32:30Z",
-    "updated_at": "2023-03-25T06:17:18Z",
+    "updated_at": "2023-03-28T01:25:07Z",
     "name": "hugo-fresh",
     "description": "Hugo Fresh Theme",
     "html_url": "https://github.com/StefMa/hugo-fresh",
-    "stargazers_count": 479
+    "stargazers_count": 481
   },
   "github.com/SteveLane/hugo-icon": {
     "id": 104065827,
@@ -515,11 +515,11 @@
   "github.com/Track3/hermit": {
     "id": 154265086,
     "created_at": "2018-10-23T04:59:56Z",
-    "updated_at": "2023-03-20T02:43:40Z",
+    "updated_at": "2023-03-27T20:32:06Z",
     "name": "hermit",
     "description": "A minimal \u0026 fast Hugo theme for bloggers",
     "html_url": "https://github.com/Track3/hermit",
-    "stargazers_count": 1038
+    "stargazers_count": 1041
   },
   "github.com/VVelox/hugo-dusky-neon-potato": {
     "id": 147290106,
@@ -542,20 +542,20 @@
   "github.com/Vimux/mainroad": {
     "id": 76561407,
     "created_at": "2016-12-15T13:21:09Z",
-    "updated_at": "2023-03-24T09:07:49Z",
+    "updated_at": "2023-03-29T03:47:24Z",
     "name": "Mainroad",
     "description": "Responsive, simple, clean and content-focused Hugo theme based on the MH Magazine lite WordPress theme",
     "html_url": "https://github.com/Vimux/Mainroad",
-    "stargazers_count": 733
+    "stargazers_count": 734
   },
   "github.com/WingLim/hugo-tania": {
     "id": 316264307,
     "created_at": "2020-11-26T15:06:12Z",
-    "updated_at": "2023-03-05T13:21:21Z",
+    "updated_at": "2023-03-28T22:19:56Z",
     "name": "hugo-tania",
     "description": "A simple theme for bloggers.",
     "html_url": "https://github.com/WingLim/hugo-tania",
-    "stargazers_count": 208
+    "stargazers_count": 209
   },
   "github.com/Xzya/hugo-material-blog": {
     "id": 130488118,
@@ -578,11 +578,11 @@
   "github.com/Yukuro/hugo-theme-shell": {
     "id": 386575752,
     "created_at": "2021-07-16T09:05:19Z",
-    "updated_at": "2023-03-19T11:08:31Z",
+    "updated_at": "2023-03-29T00:57:52Z",
     "name": "hugo-theme-shell",
     "description": "Hugo Shell theme : Terminal-like theme with selectable color schemes.",
     "html_url": "https://github.com/Yukuro/hugo-theme-shell",
-    "stargazers_count": 254
+    "stargazers_count": 256
   },
   "github.com/aanupam23/hugo-sugoi": {
     "id": 248929788,
@@ -605,11 +605,11 @@
   "github.com/adityatelange/hugo-PaperMod": {
     "id": 281297416,
     "created_at": "2020-07-21T04:45:10Z",
-    "updated_at": "2023-03-25T19:06:24Z",
+    "updated_at": "2023-03-29T15:06:54Z",
     "name": "hugo-PaperMod",
     "description": " A fast, clean, responsive Hugo theme.",
     "html_url": "https://github.com/adityatelange/hugo-PaperMod",
-    "stargazers_count": 5827
+    "stargazers_count": 5854
   },
   "github.com/aerohub/hugo-faq-theme": {
     "id": 68856818,
@@ -677,11 +677,11 @@
   "github.com/alex-shpak/hugo-book": {
     "id": 147530276,
     "created_at": "2018-09-05T14:21:31Z",
-    "updated_at": "2023-03-25T08:52:55Z",
+    "updated_at": "2023-03-29T13:08:46Z",
     "name": "hugo-book",
     "description": "Hugo documentation theme as simple as plain book",
     "html_url": "https://github.com/alex-shpak/hugo-book",
-    "stargazers_count": 2267
+    "stargazers_count": 2271
   },
   "github.com/alexandrevicenzi/soho": {
     "id": 239386232,
@@ -749,16 +749,16 @@
   "github.com/apvarun/blist-hugo-theme": {
     "id": 386273576,
     "created_at": "2021-07-15T11:59:59Z",
-    "updated_at": "2023-03-25T08:58:05Z",
+    "updated_at": "2023-03-26T20:53:48Z",
     "name": "blist-hugo-theme",
     "description": "Blist is a clean and fast blog theme for your Hugo site.",
     "html_url": "https://github.com/apvarun/blist-hugo-theme",
-    "stargazers_count": 238
+    "stargazers_count": 240
   },
   "github.com/apvarun/digital-garden-hugo-theme": {
     "id": 439232849,
     "created_at": "2021-12-17T06:26:49Z",
-    "updated_at": "2023-03-15T10:38:42Z",
+    "updated_at": "2023-03-29T03:42:41Z",
     "name": "digital-garden-hugo-theme",
     "description": "Build your own personal Digital Garden effortlessly with this Hugo theme",
     "html_url": "https://github.com/apvarun/digital-garden-hugo-theme",
@@ -794,11 +794,11 @@
   "github.com/athul/archie": {
     "id": 253427252,
     "created_at": "2020-04-06T07:35:38Z",
-    "updated_at": "2023-03-25T13:53:36Z",
+    "updated_at": "2023-03-29T04:17:40Z",
     "name": "archie",
     "description": "A minimal Hugo Theme",
     "html_url": "https://github.com/athul/archie",
-    "stargazers_count": 646
+    "stargazers_count": 647
   },
   "github.com/austingebauer/devise": {
     "id": 193039721,
@@ -812,11 +812,11 @@
   "github.com/azmelanar/hugo-theme-pixyll": {
     "id": 26679163,
     "created_at": "2014-11-15T12:25:29Z",
-    "updated_at": "2023-03-15T17:02:27Z",
+    "updated_at": "2023-03-26T15:53:44Z",
     "name": "hugo-theme-pixyll",
     "description": "A simple, beautiful Hugo theme that's mobile first.",
     "html_url": "https://github.com/azmelanar/hugo-theme-pixyll",
-    "stargazers_count": 173
+    "stargazers_count": 172
   },
   "github.com/bake/solar-theme-hugo": {
     "id": 98172335,
@@ -839,20 +839,20 @@
   "github.com/bep/docuapi/v2": {
     "id": 71171466,
     "created_at": "2016-10-17T19:02:31Z",
-    "updated_at": "2023-03-24T12:46:11Z",
+    "updated_at": "2023-03-28T22:49:54Z",
     "name": "docuapi",
     "description": "Beautiful multilingual API documentation theme for Hugo",
     "html_url": "https://github.com/bep/docuapi",
-    "stargazers_count": 659
+    "stargazers_count": 663
   },
   "github.com/bep/gallerydeluxe": {
     "id": 538049920,
     "created_at": "2022-09-18T08:44:48Z",
-    "updated_at": "2023-03-05T07:37:43Z",
+    "updated_at": "2023-03-29T12:12:44Z",
     "name": "gallerydeluxe",
     "description": "Fast Hugo gallery theme/module suitable for lots of images.",
     "html_url": "https://github.com/bep/gallerydeluxe",
-    "stargazers_count": 67
+    "stargazers_count": 69
   },
   "github.com/bjacquemet/personal-web": {
     "id": 172538739,
@@ -875,7 +875,7 @@
   "github.com/boratanrikulu/eternity": {
     "id": 517383455,
     "created_at": "2022-07-24T16:54:31Z",
-    "updated_at": "2023-03-20T06:38:55Z",
+    "updated_at": "2023-03-28T13:24:19Z",
     "name": "eternity",
     "description": "A minimalist Hugo theme designed for portfolio sites.",
     "html_url": "https://github.com/boratanrikulu/eternity",
@@ -911,11 +911,11 @@
   "github.com/canhtran/maverick": {
     "id": 507482239,
     "created_at": "2022-06-26T05:04:55Z",
-    "updated_at": "2023-03-25T02:30:47Z",
+    "updated_at": "2023-03-26T13:06:51Z",
     "name": "maverick",
     "description": "A minimal hugo theme focus on content",
     "html_url": "https://github.com/canhtran/maverick",
-    "stargazers_count": 20
+    "stargazers_count": 21
   },
   "github.com/canstand/compost": {
     "id": 410851914,
@@ -1001,11 +1001,11 @@
   "github.com/charlola/hugo-theme-charlolamode": {
     "id": 570720430,
     "created_at": "2022-11-25T23:18:14Z",
-    "updated_at": "2023-03-22T21:30:50Z",
+    "updated_at": "2023-03-28T16:48:37Z",
     "name": "hugo-theme-charlolamode",
     "description": "This is a minimalistic theme template for websites. ",
     "html_url": "https://github.com/charlola/hugo-theme-charlolamode",
-    "stargazers_count": 61
+    "stargazers_count": 62
   },
   "github.com/chipsenkbeil/grid-side": {
     "id": 40447662,
@@ -1019,11 +1019,11 @@
   "github.com/chipzoller/hugo-clarity": {
     "id": 256256206,
     "created_at": "2020-04-16T15:31:58Z",
-    "updated_at": "2023-03-25T03:27:54Z",
+    "updated_at": "2023-03-28T14:16:48Z",
     "name": "hugo-clarity",
     "description": "A theme for Hugo based on VMware Clarity",
     "html_url": "https://github.com/chipzoller/hugo-clarity",
-    "stargazers_count": 493
+    "stargazers_count": 495
   },
   "github.com/chollinger93/ink-free": {
     "id": 270338664,
@@ -1046,11 +1046,11 @@
   "github.com/clente/hugo-bearcub": {
     "id": 596196165,
     "created_at": "2023-02-01T17:08:46Z",
-    "updated_at": "2023-03-24T06:39:26Z",
+    "updated_at": "2023-03-26T15:59:59Z",
     "name": "hugo-bearcub",
     "description": "🐻 A lightweight Hugo theme based on Bear Blog and Hugo Bear Blog",
     "html_url": "https://github.com/clente/hugo-bearcub",
-    "stargazers_count": 7
+    "stargazers_count": 8
   },
   "github.com/cloudwithchris/hugo-creator": {
     "id": 452811529,
@@ -1100,11 +1100,11 @@
   "github.com/cowboysmall-tools/hugo-devresume-theme": {
     "id": 219337339,
     "created_at": "2019-11-03T17:19:06Z",
-    "updated_at": "2023-03-22T04:08:47Z",
+    "updated_at": "2023-03-28T08:19:11Z",
     "name": "hugo-devresume-theme",
     "description": "A free resume/CV template made for software developers.",
     "html_url": "https://github.com/cowboysmall-tools/hugo-devresume-theme",
-    "stargazers_count": 223
+    "stargazers_count": 226
   },
   "github.com/cristianmarint/sicily-hugo-theme": {
     "id": 302672989,
@@ -1271,11 +1271,11 @@
   "github.com/davidhampgonsalves/hugo-black-and-light-theme": {
     "id": 78483943,
     "created_at": "2017-01-10T01:03:05Z",
-    "updated_at": "2023-03-02T01:41:10Z",
+    "updated_at": "2023-03-26T00:48:47Z",
     "name": "hugo-black-and-light-theme",
     "description": "",
     "html_url": "https://github.com/davidhampgonsalves/hugo-black-and-light-theme",
-    "stargazers_count": 177
+    "stargazers_count": 176
   },
   "github.com/de-souza/hugo-flex": {
     "id": 171150963,
@@ -1289,11 +1289,11 @@
   "github.com/devcows/hugo-universal-theme": {
     "id": 61122259,
     "created_at": "2016-06-14T12:47:40Z",
-    "updated_at": "2023-03-24T04:55:58Z",
+    "updated_at": "2023-03-28T01:24:37Z",
     "name": "hugo-universal-theme",
     "description": "Universal theme for Hugo, it stands out with its clean design and elegant typography.",
     "html_url": "https://github.com/devcows/hugo-universal-theme",
-    "stargazers_count": 662
+    "stargazers_count": 663
   },
   "github.com/dewittn/hugo-html5up-alpha": {
     "id": 262763794,
@@ -1307,11 +1307,11 @@
   "github.com/dillonzq/LoveIt": {
     "id": 200158234,
     "created_at": "2019-08-02T03:27:11Z",
-    "updated_at": "2023-03-25T18:06:52Z",
+    "updated_at": "2023-03-29T08:19:20Z",
     "name": "LoveIt",
     "description": "❤️A clean, elegant but advanced blog theme for Hugo 一个简洁、优雅且高效的 Hugo 主题",
     "html_url": "https://github.com/dillonzq/LoveIt",
-    "stargazers_count": 2764
+    "stargazers_count": 2772
   },
   "github.com/diwao/hestia-pure": {
     "id": 95651197,
@@ -1352,20 +1352,20 @@
   "github.com/dsrkafuu/hugo-theme-fuji": {
     "id": 255303954,
     "created_at": "2020-04-13T11:11:20Z",
-    "updated_at": "2023-03-21T14:41:31Z",
+    "updated_at": "2023-03-29T14:34:25Z",
     "name": "hugo-theme-fuji",
     "description": "A minimal Hugo theme with nice theme color. | 一个主题色极简 Hugo 主题。",
     "html_url": "https://github.com/dsrkafuu/hugo-theme-fuji",
-    "stargazers_count": 341
+    "stargazers_count": 342
   },
   "github.com/dzello/reveal-hugo": {
     "id": 131216648,
     "created_at": "2018-04-26T22:21:56Z",
-    "updated_at": "2023-03-25T10:10:01Z",
+    "updated_at": "2023-03-28T04:17:33Z",
     "name": "reveal-hugo",
     "description": "📽️ Create rich HTML-based presentations with Hugo and Reveal.js",
     "html_url": "https://github.com/dzello/reveal-hugo",
-    "stargazers_count": 572
+    "stargazers_count": 574
   },
   "github.com/edavidaja/docter": {
     "id": 190885811,
@@ -1460,11 +1460,11 @@
   "github.com/floyd-li/hugo-theme-itheme": {
     "id": 610285593,
     "created_at": "2023-03-06T13:22:28Z",
-    "updated_at": "2023-03-23T00:33:15Z",
+    "updated_at": "2023-03-28T08:00:10Z",
     "name": "hugo-theme-itheme",
     "description": "An Apple style theme for hugo",
     "html_url": "https://github.com/floyd-li/hugo-theme-itheme",
-    "stargazers_count": 14
+    "stargazers_count": 15
   },
   "github.com/fncnt/vncnt-hugo": {
     "id": 163980744,
@@ -1478,11 +1478,11 @@
   "github.com/forestryio/hugo-theme-novela": {
     "id": 213727505,
     "created_at": "2019-10-08T18:56:51Z",
-    "updated_at": "2023-03-25T10:40:35Z",
+    "updated_at": "2023-03-28T02:33:45Z",
     "name": "hugo-theme-novela",
     "description": "Novela, the simplest way to start publishing with Hugo and Forestry.",
     "html_url": "https://github.com/forestryio/hugo-theme-novela",
-    "stargazers_count": 349
+    "stargazers_count": 351
   },
   "github.com/fourtyone11/origin-hugo-theme": {
     "id": 242563620,
@@ -1613,11 +1613,11 @@
   "github.com/google/docsy": {
     "id": 153180924,
     "created_at": "2018-10-15T20:59:47Z",
-    "updated_at": "2023-03-25T15:35:34Z",
+    "updated_at": "2023-03-29T12:21:22Z",
     "name": "docsy",
     "description": "A set of Hugo doc templates for launching open source content.",
     "html_url": "https://github.com/google/docsy",
-    "stargazers_count": 2109
+    "stargazers_count": 2124
   },
   "github.com/guangmean/Niello": {
     "id": 163953752,
@@ -1649,11 +1649,11 @@
   "github.com/gurusabarish/hugo-profile": {
     "id": 287894238,
     "created_at": "2020-08-16T07:19:04Z",
-    "updated_at": "2023-03-24T19:35:37Z",
+    "updated_at": "2023-03-29T12:30:45Z",
     "name": "hugo-profile",
     "description": "A highly customizable and mobile first Hugo template for personal portfolio and blog.",
     "html_url": "https://github.com/gurusabarish/hugo-profile",
-    "stargazers_count": 340
+    "stargazers_count": 344
   },
   "github.com/gyorb/hugo-dusk": {
     "id": 89065581,
@@ -1667,11 +1667,11 @@
   "github.com/h-enk/doks": {
     "id": 255927625,
     "created_at": "2020-04-15T13:37:31Z",
-    "updated_at": "2023-03-25T15:33:24Z",
+    "updated_at": "2023-03-29T11:18:34Z",
     "name": "doks",
     "description": "Hugo theme helping you build modern documentation websites.",
     "html_url": "https://github.com/h-enk/doks",
-    "stargazers_count": 1489
+    "stargazers_count": 1497
   },
   "github.com/hadisinaee/avicenna": {
     "id": 194403815,
@@ -1694,7 +1694,7 @@
   "github.com/halogenica/beautifulhugo": {
     "id": 53404533,
     "created_at": "2016-03-08T10:44:16Z",
-    "updated_at": "2023-03-20T03:35:34Z",
+    "updated_at": "2023-03-28T01:06:26Z",
     "name": "beautifulhugo",
     "description": "Theme for the Hugo static website generator",
     "html_url": "https://github.com/halogenica/beautifulhugo",
@@ -1739,7 +1739,7 @@
   "github.com/hivickylai/hugo-theme-sam": {
     "id": 121534430,
     "created_at": "2018-02-14T16:37:53Z",
-    "updated_at": "2023-03-20T10:24:05Z",
+    "updated_at": "2023-03-27T00:19:56Z",
     "name": "hugo-theme-sam",
     "description": "A Simple and Minimalist theme for Hugo with a focus on typography and content.",
     "html_url": "https://github.com/victoriadrake/hugo-theme-sam",
@@ -1766,11 +1766,11 @@
   "github.com/hossainemruz/toha": {
     "id": 254809249,
     "created_at": "2020-04-11T06:42:21Z",
-    "updated_at": "2023-03-21T14:27:09Z",
+    "updated_at": "2023-03-29T13:04:31Z",
     "name": "toha",
     "description": "A Hugo theme for personal portfolio",
     "html_url": "https://github.com/hugo-toha/toha",
-    "stargazers_count": 732
+    "stargazers_count": 736
   },
   "github.com/hotjuicew/hugo-JuiceBar": {
     "id": 479781607,
@@ -1820,29 +1820,29 @@
   "github.com/hugo-fixit/FixIt": {
     "id": 438849461,
     "created_at": "2021-12-16T03:35:27Z",
-    "updated_at": "2023-03-25T06:07:27Z",
+    "updated_at": "2023-03-29T06:09:59Z",
     "name": "FixIt",
     "description": "🔧 A clean, elegant but advanced blog theme for Hugo 一个简洁、优雅且高效的 Hugo 主题",
     "html_url": "https://github.com/hugo-fixit/FixIt",
-    "stargazers_count": 230
+    "stargazers_count": 231
   },
   "github.com/hugo-next/hugo-theme-next": {
     "id": 488167192,
     "created_at": "2022-05-03T10:37:57Z",
-    "updated_at": "2023-03-23T06:01:27Z",
+    "updated_at": "2023-03-28T01:35:17Z",
     "name": "hugo-theme-next",
     "description": "Easily \u0026 powerful theme for Hugo engine.",
     "html_url": "https://github.com/hugo-next/hugo-theme-next",
-    "stargazers_count": 121
+    "stargazers_count": 122
   },
   "github.com/hugo-sid/hugo-blog-awesome": {
     "id": 601457559,
     "created_at": "2023-02-14T05:18:30Z",
-    "updated_at": "2023-03-25T16:20:00Z",
+    "updated_at": "2023-03-29T11:50:24Z",
     "name": "hugo-blog-awesome",
     "description": "Fast, minimal blog with dark mode support.",
     "html_url": "https://github.com/hugo-sid/hugo-blog-awesome",
-    "stargazers_count": 29
+    "stargazers_count": 35
   },
   "github.com/humrochagf/colordrop": {
     "id": 198533025,
@@ -1955,20 +1955,20 @@
   "github.com/jakewies/hugo-theme-codex": {
     "id": 269444058,
     "created_at": "2020-06-04T19:13:28Z",
-    "updated_at": "2023-03-15T17:14:48Z",
+    "updated_at": "2023-03-28T11:01:59Z",
     "name": "hugo-theme-codex",
     "description": "A minimal blog theme for Hugo  🍜",
     "html_url": "https://github.com/jakewies/hugo-theme-codex",
-    "stargazers_count": 327
+    "stargazers_count": 326
   },
   "github.com/janraasch/hugo-bearblog": {
     "id": 291975591,
     "created_at": "2020-09-01T11:10:57Z",
-    "updated_at": "2023-03-24T14:01:03Z",
+    "updated_at": "2023-03-27T11:51:42Z",
     "name": "hugo-bearblog",
     "description": "🧸 A Hugo theme based on »Bear Blog«. Free, no-nonsense, super-fast blogging. This theme now includes a dark color scheme to support dark mode 🦉 ⬛️!",
     "html_url": "https://github.com/janraasch/hugo-bearblog",
-    "stargazers_count": 472
+    "stargazers_count": 477
   },
   "github.com/janraasch/hugo-product-launch": {
     "id": 289950463,
@@ -2000,11 +2000,11 @@
   "github.com/jeremybise/twentynineteen-hugo": {
     "id": 181497207,
     "created_at": "2019-04-15T13:51:41Z",
-    "updated_at": "2022-10-22T09:22:44Z",
+    "updated_at": "2023-03-26T15:50:01Z",
     "name": "twentynineteen-hugo",
     "description": "A Hugo theme based on the Wordpress Twenty Nineteen theme.",
     "html_url": "https://github.com/jeremybise/twentynineteen-hugo",
-    "stargazers_count": 9
+    "stargazers_count": 8
   },
   "github.com/jesselau76/hugo-w3-simple": {
     "id": 156296660,
@@ -2018,11 +2018,11 @@
   "github.com/jgazeau/shadocs": {
     "id": 329419621,
     "created_at": "2021-01-13T20:08:43Z",
-    "updated_at": "2023-03-24T06:54:21Z",
+    "updated_at": "2023-03-29T09:02:21Z",
     "name": "shadocs",
     "description": "Shadocs Theme for Hugo",
     "html_url": "https://github.com/jgazeau/shadocs",
-    "stargazers_count": 24
+    "stargazers_count": 26
   },
   "github.com/jimfrenette/hugo-starter": {
     "id": 167275593,
@@ -2063,7 +2063,7 @@
   "github.com/joeroe/risotto": {
     "id": 344763910,
     "created_at": "2021-03-05T09:45:15Z",
-    "updated_at": "2023-03-25T13:19:33Z",
+    "updated_at": "2023-03-28T14:27:00Z",
     "name": "risotto",
     "description": "A minimalist, responsive hugo theme inspired by terminal ricing aesthetics.",
     "html_url": "https://github.com/joeroe/risotto",
@@ -2081,11 +2081,11 @@
   "github.com/joseph-mccarthy/hugo-bootstrap-freelancer-template": {
     "id": 458968701,
     "created_at": "2022-02-14T00:33:19Z",
-    "updated_at": "2023-01-20T02:05:42Z",
+    "updated_at": "2023-03-28T03:37:47Z",
     "name": "hugo-bootstrap-freelancer-template",
     "description": "Hugo Bootstrap Freelancer Theme. Based on the startBootStrap Freelancer theme.",
     "html_url": "https://github.com/joseph-mccarthy/hugo-bootstrap-freelancer-template",
-    "stargazers_count": 4
+    "stargazers_count": 5
   },
   "github.com/josephhutch/aether": {
     "id": 125391209,
@@ -2108,29 +2108,29 @@
   "github.com/joway/hugo-theme-yinyang": {
     "id": 156729664,
     "created_at": "2018-11-08T15:41:32Z",
-    "updated_at": "2023-03-25T10:46:09Z",
+    "updated_at": "2023-03-28T21:22:00Z",
     "name": "hugo-theme-yinyang",
     "description": "A black-white theme for Hugo.",
     "html_url": "https://github.com/joway/hugo-theme-yinyang",
-    "stargazers_count": 406
+    "stargazers_count": 407
   },
   "github.com/jpanther/congo": {
     "id": 394873267,
     "created_at": "2021-08-11T05:29:45Z",
-    "updated_at": "2023-03-25T15:24:20Z",
+    "updated_at": "2023-03-29T01:44:47Z",
     "name": "congo",
     "description": "A powerful, lightweight theme for Hugo built with Tailwind CSS.",
     "html_url": "https://github.com/jpanther/congo",
-    "stargazers_count": 669
+    "stargazers_count": 673
   },
   "github.com/jpanther/lynx": {
     "id": 423043182,
     "created_at": "2021-10-31T03:26:52Z",
-    "updated_at": "2023-03-23T12:09:36Z",
+    "updated_at": "2023-03-27T07:09:48Z",
     "name": "lynx",
     "description": "A simple links theme for Hugo built with Tailwind CSS.",
     "html_url": "https://github.com/jpanther/lynx",
-    "stargazers_count": 165
+    "stargazers_count": 166
   },
   "github.com/jpescador/hugo-future-imperfect": {
     "id": 54349132,
@@ -2189,20 +2189,20 @@
   "github.com/kaiiiz/hugo-theme-monochrome": {
     "id": 335465577,
     "created_at": "2021-02-03T00:49:22Z",
-    "updated_at": "2023-03-16T15:02:51Z",
+    "updated_at": "2023-03-27T06:45:46Z",
     "name": "hugo-theme-monochrome",
     "description": "Monochrome is a fast, clean and responsive hugo theme",
     "html_url": "https://github.com/kaiiiz/hugo-theme-monochrome",
-    "stargazers_count": 94
+    "stargazers_count": 96
   },
   "github.com/kakawait/hugo-tranquilpeak-theme": {
     "id": 55093419,
     "created_at": "2016-03-30T19:55:05Z",
-    "updated_at": "2023-03-20T10:48:31Z",
+    "updated_at": "2023-03-28T08:35:17Z",
     "name": "hugo-tranquilpeak-theme",
     "description": "A gorgeous responsive theme for Hugo blog framework",
     "html_url": "https://github.com/kakawait/hugo-tranquilpeak-theme",
-    "stargazers_count": 867
+    "stargazers_count": 868
   },
   "github.com/kaushalmodi/hugo-bare-min-theme": {
     "id": 119444825,
@@ -2405,11 +2405,11 @@
   "github.com/loveminimal/hugo-theme-virgo": {
     "id": 505842068,
     "created_at": "2022-06-21T12:52:48Z",
-    "updated_at": "2023-03-23T14:44:47Z",
+    "updated_at": "2023-03-29T04:18:01Z",
     "name": "hugo-theme-virgo",
     "description": "A simple  and pure theme.",
     "html_url": "https://github.com/loveminimal/hugo-theme-virgo",
-    "stargazers_count": 48
+    "stargazers_count": 49
   },
   "github.com/lubang/hugo-hello-programmer-theme": {
     "id": 74281084,
@@ -2423,29 +2423,20 @@
   "github.com/luizdepra/hugo-coder": {
     "id": 121858752,
     "created_at": "2018-02-17T13:45:54Z",
-    "updated_at": "2023-03-25T18:42:53Z",
+    "updated_at": "2023-03-29T14:03:36Z",
     "name": "hugo-coder",
     "description": "A minimalist blog theme for hugo.",
     "html_url": "https://github.com/luizdepra/hugo-coder",
-    "stargazers_count": 2235
-  },
-  "github.com/lukeorth/poison": {
-    "id": 561766096,
-    "created_at": "2022-11-04T12:51:34Z",
-    "updated_at": "2023-03-25T17:10:06Z",
-    "name": "poison",
-    "description": "Professional Hugo theme for dev bloggers.  Based on Mdo's classic Hyde theme.",
-    "html_url": "https://github.com/lukeorth/poison",
-    "stargazers_count": 42
+    "stargazers_count": 2241
   },
   "github.com/lxndrblz/anatole": {
     "id": 254723453,
     "created_at": "2020-04-10T19:53:00Z",
-    "updated_at": "2023-03-20T16:19:40Z",
+    "updated_at": "2023-03-27T07:10:20Z",
     "name": "anatole",
     "description": "Anatole is a minimalistic two-column theme for Hugo.",
     "html_url": "https://github.com/lxndrblz/anatole",
-    "stargazers_count": 568
+    "stargazers_count": 571
   },
   "github.com/marcanuy/simpleit-hugo-theme": {
     "id": 143778607,
@@ -2459,11 +2450,11 @@
   "github.com/markdumay/hugo-theme-hinode": {
     "id": 447086741,
     "created_at": "2022-01-12T05:20:40Z",
-    "updated_at": "2023-03-21T16:53:05Z",
+    "updated_at": "2023-03-27T15:50:35Z",
     "name": "hinode",
     "description": "A clean documentation and blog theme for your Hugo site based on Bootstrap 5",
     "html_url": "https://github.com/gethinode/hinode",
-    "stargazers_count": 27
+    "stargazers_count": 28
   },
   "github.com/marketempower/axiom": {
     "id": 256073917,
@@ -2477,11 +2468,11 @@
   "github.com/matcornic/hugo-theme-learn": {
     "id": 54111104,
     "created_at": "2016-03-17T10:58:41Z",
-    "updated_at": "2023-03-25T15:33:48Z",
+    "updated_at": "2023-03-27T07:11:38Z",
     "name": "hugo-theme-learn",
     "description": "Porting Grav Learn theme to Hugo",
     "html_url": "https://github.com/matcornic/hugo-theme-learn",
-    "stargazers_count": 1511
+    "stargazers_count": 1512
   },
   "github.com/matsuyoshi30/harbor": {
     "id": 240560413,
@@ -2513,11 +2504,11 @@
   "github.com/mavidser/hugo-rocinante": {
     "id": 245127512,
     "created_at": "2020-03-05T10:01:41Z",
-    "updated_at": "2023-03-23T10:05:59Z",
+    "updated_at": "2023-03-29T09:44:58Z",
     "name": "hugo-rocinante",
     "description": "Minimal and very lightweight hugo theme.",
     "html_url": "https://github.com/mavidser/hugo-rocinante",
-    "stargazers_count": 40
+    "stargazers_count": 41
   },
   "github.com/mazgi/hugo-theme-techlog-simple": {
     "id": 151939789,
@@ -2603,11 +2594,11 @@
   "github.com/mivinci/hugo-theme-minima": {
     "id": 387123645,
     "created_at": "2021-07-18T08:06:57Z",
-    "updated_at": "2023-03-22T13:10:34Z",
+    "updated_at": "2023-03-28T11:01:42Z",
     "name": "hugo-theme-minima",
     "description": "A clean and minimal Hugo theme.",
     "html_url": "https://github.com/mivinci/hugo-theme-minima",
-    "stargazers_count": 83
+    "stargazers_count": 82
   },
   "github.com/mmrath/hugo-bootstrap": {
     "id": 45042153,
@@ -2621,7 +2612,7 @@
   "github.com/monkeyWzr/hugo-theme-cactus": {
     "id": 278695182,
     "created_at": "2020-07-10T17:32:58Z",
-    "updated_at": "2023-03-21T23:52:42Z",
+    "updated_at": "2023-03-28T14:43:46Z",
     "name": "hugo-theme-cactus",
     "description": "Cactus theme for hugo",
     "html_url": "https://github.com/monkeyWzr/hugo-theme-cactus",
@@ -2639,11 +2630,11 @@
   "github.com/nanxiaobei/hugo-paper": {
     "id": 116700454,
     "created_at": "2018-01-08T16:26:30Z",
-    "updated_at": "2023-03-25T15:46:33Z",
+    "updated_at": "2023-03-29T07:53:16Z",
     "name": "hugo-paper",
     "description": "🪺 A simple, clean, flexible Hugo theme",
     "html_url": "https://github.com/nanxiaobei/hugo-paper",
-    "stargazers_count": 1420
+    "stargazers_count": 1424
   },
   "github.com/nanxstats/hugo-tanka": {
     "id": 115429784,
@@ -2720,20 +2711,20 @@
   "github.com/nixentric/Lowkey-Hugo-Theme": {
     "id": 583892827,
     "created_at": "2022-12-31T10:48:22Z",
-    "updated_at": "2023-03-20T12:06:07Z",
+    "updated_at": "2023-03-29T03:41:37Z",
     "name": "Lowkey-Hugo-Theme",
     "description": "A Simple \u0026 Humble Hugo Themes",
     "html_url": "https://github.com/nixentric/Lowkey-Hugo-Theme",
-    "stargazers_count": 6
+    "stargazers_count": 7
   },
   "github.com/nodejh/hugo-theme-cactus-plus": {
     "id": 79039278,
     "created_at": "2017-01-15T14:56:47Z",
-    "updated_at": "2023-03-21T19:55:21Z",
+    "updated_at": "2023-03-29T03:32:45Z",
     "name": "hugo-theme-mini",
     "description": "A fast, minimalist and responsive hugo theme for bloggers.",
     "html_url": "https://github.com/nodejh/hugo-theme-mini",
-    "stargazers_count": 613
+    "stargazers_count": 615
   },
   "github.com/ntk148v/hugo-cuisine-book": {
     "id": 513742307,
@@ -2756,11 +2747,11 @@
   "github.com/nunocoracao/blowfish": {
     "id": 534798642,
     "created_at": "2022-09-09T20:38:52Z",
-    "updated_at": "2023-03-25T19:04:17Z",
+    "updated_at": "2023-03-29T01:52:15Z",
     "name": "blowfish",
     "description": "Personal Website \u0026 Blog Theme for Hugo",
     "html_url": "https://github.com/nunocoracao/blowfish",
-    "stargazers_count": 331
+    "stargazers_count": 336
   },
   "github.com/nurlansu/hugo-sustain": {
     "id": 71623522,
@@ -2774,38 +2765,38 @@
   "github.com/nusserstudios/tailbliss": {
     "id": 559039482,
     "created_at": "2022-10-28T22:19:46Z",
-    "updated_at": "2023-03-22T18:39:07Z",
+    "updated_at": "2023-03-26T17:03:30Z",
     "name": "tailbliss",
     "description": "TailBliss is a Hugo Starter theme built on TailwindCSS 3, and Alpine.JS.",
     "html_url": "https://github.com/nusserstudios/tailbliss",
-    "stargazers_count": 81
+    "stargazers_count": 82
   },
   "github.com/okkur/syna": {
     "id": 102731022,
     "created_at": "2017-09-07T11:51:44Z",
-    "updated_at": "2023-03-06T14:29:35Z",
+    "updated_at": "2023-03-26T01:53:38Z",
     "name": "syna",
     "description": "Highly customizable open source theme for Hugo based static websites",
     "html_url": "https://github.com/okkur/syna",
-    "stargazers_count": 251
+    "stargazers_count": 252
   },
   "github.com/olOwOlo/hugo-theme-even": {
     "id": 101626459,
     "created_at": "2017-08-28T09:20:45Z",
-    "updated_at": "2023-03-25T16:29:20Z",
+    "updated_at": "2023-03-29T00:32:04Z",
     "name": "hugo-theme-even",
     "description": "🚀 A super concise theme for Hugo https://hugo-theme-even.netlify.app",
     "html_url": "https://github.com/olOwOlo/hugo-theme-even",
-    "stargazers_count": 1914
+    "stargazers_count": 1915
   },
   "github.com/onweru/compose": {
     "id": 236832189,
     "created_at": "2020-01-28T20:17:23Z",
-    "updated_at": "2023-03-25T03:14:11Z",
+    "updated_at": "2023-03-28T18:09:13Z",
     "name": "compose",
     "description": "A Hugo theme for documentation sites. It's inspired by https://forestry.io/docs/welcome/",
     "html_url": "https://github.com/onweru/compose",
-    "stargazers_count": 219
+    "stargazers_count": 220
   },
   "github.com/onweru/hugo-swift-theme": {
     "id": 170762804,
@@ -2864,29 +2855,29 @@
   "github.com/pacollins/calligraphy": {
     "id": 473825609,
     "created_at": "2022-03-25T01:13:39Z",
-    "updated_at": "2023-03-25T08:55:05Z",
+    "updated_at": "2023-03-27T07:40:04Z",
     "name": "calligraphy",
     "description": "Calligraphy is a theme for Hugo static site generator focused on the beauty of it's content.",
     "html_url": "https://github.com/pacollins/calligraphy",
-    "stargazers_count": 20
+    "stargazers_count": 21
   },
   "github.com/panr/hugo-theme-hello-friend": {
     "id": 141738551,
     "created_at": "2018-07-20T17:13:14Z",
-    "updated_at": "2023-03-25T15:30:06Z",
+    "updated_at": "2023-03-28T14:26:59Z",
     "name": "hugo-theme-hello-friend",
     "description": "Pretty basic theme for Hugo that covers all of the essentials. All you have to do is start typing!",
     "html_url": "https://github.com/panr/hugo-theme-hello-friend",
-    "stargazers_count": 1011
+    "stargazers_count": 1010
   },
   "github.com/panr/hugo-theme-terminal": {
     "id": 167872853,
     "created_at": "2019-01-27T23:58:03Z",
-    "updated_at": "2023-03-24T16:23:46Z",
+    "updated_at": "2023-03-29T08:14:49Z",
     "name": "hugo-theme-terminal",
     "description": "A simple, retro theme for Hugo",
     "html_url": "https://github.com/panr/hugo-theme-terminal",
-    "stargazers_count": 1696
+    "stargazers_count": 1698
   },
   "github.com/parsiya/Hugo-Octopress": {
     "id": 50900827,
@@ -2972,11 +2963,11 @@
   "github.com/plopcas/papaya": {
     "id": 236103215,
     "created_at": "2020-01-24T23:52:39Z",
-    "updated_at": "2023-03-05T16:40:07Z",
+    "updated_at": "2023-03-28T10:14:11Z",
     "name": "papaya",
     "description": "Minimalist Hugo theme with social buttons and analytics.",
     "html_url": "https://github.com/plopcas/papaya",
-    "stargazers_count": 23
+    "stargazers_count": 24
   },
   "github.com/pravin/hugo-theme-prav": {
     "id": 230786786,
@@ -3071,16 +3062,16 @@
   "github.com/razonyang/hugo-theme-bootstrap": {
     "id": 304332853,
     "created_at": "2020-10-15T13:20:45Z",
-    "updated_at": "2023-03-19T17:59:18Z",
+    "updated_at": "2023-03-27T09:29:05Z",
     "name": "hugo-theme-bootstrap",
     "description": "A fast, responsive, multipurpose and feature-rich Hugo theme.",
     "html_url": "https://github.com/razonyang/hugo-theme-bootstrap",
-    "stargazers_count": 352
+    "stargazers_count": 353
   },
   "github.com/reuixiy/hugo-theme-meme": {
     "id": 201855709,
     "created_at": "2019-08-12T04:06:21Z",
-    "updated_at": "2023-03-24T16:09:09Z",
+    "updated_at": "2023-03-27T03:45:56Z",
     "name": "hugo-theme-meme",
     "description": "You can’t spell aWEsoME without MEME! 😝",
     "html_url": "https://github.com/reuixiy/hugo-theme-meme",
@@ -3089,11 +3080,11 @@
   "github.com/rhazdon/hugo-theme-hello-friend-ng": {
     "id": 167668309,
     "created_at": "2019-01-26T08:46:36Z",
-    "updated_at": "2023-03-25T16:27:37Z",
+    "updated_at": "2023-03-28T19:32:12Z",
     "name": "hugo-theme-hello-friend-ng",
     "description": "Pretty basic theme for Hugo that covers all of the essentials. All you have to do is start typing!",
     "html_url": "https://github.com/rhazdon/hugo-theme-hello-friend-ng",
-    "stargazers_count": 1275
+    "stargazers_count": 1276
   },
   "github.com/rhnvrm/bodhi": {
     "id": 265294756,
@@ -3152,11 +3143,11 @@
   "github.com/runningstream/hugograyscale": {
     "id": 148952560,
     "created_at": "2018-09-16T01:12:43Z",
-    "updated_at": "2023-03-01T05:59:38Z",
+    "updated_at": "2023-03-29T08:02:18Z",
     "name": "hugograyscale",
     "description": "A multi-section single page theme intended as a landing page.  This is derived from the startbootstrap-grayscale theme.",
     "html_url": "https://github.com/runningstream/hugograyscale",
-    "stargazers_count": 46
+    "stargazers_count": 47
   },
   "github.com/rz3n/hugo-theme-freshstart": {
     "id": 285397747,
@@ -3179,7 +3170,7 @@
   "github.com/saadnpq/npq-hugo": {
     "id": 254852946,
     "created_at": "2020-04-11T11:27:48Z",
-    "updated_at": "2022-03-23T10:22:09Z",
+    "updated_at": "2023-03-27T22:53:31Z",
     "name": "npqhugo",
     "description": "npq-hugo is a customizable and responsive dark blog theme with integrated contact form and code syntax highlighting",
     "html_url": "https://github.com/saadsolimanxyz/npqhugo",
@@ -3314,11 +3305,11 @@
   "github.com/shaform/hugo-theme-den": {
     "id": 141029583,
     "created_at": "2018-07-15T13:29:45Z",
-    "updated_at": "2023-03-25T16:44:54Z",
+    "updated_at": "2023-03-26T12:44:56Z",
     "name": "hugo-theme-den",
     "description": "A Simple Theme for Hugo",
     "html_url": "https://github.com/shaform/hugo-theme-den",
-    "stargazers_count": 33
+    "stargazers_count": 34
   },
   "github.com/shenoybr/hugo-goa": {
     "id": 70299290,
@@ -3467,11 +3458,11 @@
   "github.com/syui/hugo-theme-air": {
     "id": 39655060,
     "created_at": "2015-07-24T20:15:24Z",
-    "updated_at": "2023-03-20T18:38:55Z",
+    "updated_at": "2023-03-27T11:56:35Z",
     "name": "hugo-theme-air",
     "description": "cname : syui.cf",
     "html_url": "https://github.com/syui/hugo-theme-air",
-    "stargazers_count": 133
+    "stargazers_count": 134
   },
   "github.com/syui/hugo-theme-wave": {
     "id": 60361500,
@@ -3485,11 +3476,11 @@
   "github.com/taikii/whiteplain": {
     "id": 115015872,
     "created_at": "2017-12-21T14:43:28Z",
-    "updated_at": "2023-03-05T16:59:41Z",
+    "updated_at": "2023-03-28T17:05:15Z",
     "name": "whiteplain",
     "description": "Simple and Functional Hugo theme.",
     "html_url": "https://github.com/taikii/whiteplain",
-    "stargazers_count": 103
+    "stargazers_count": 105
   },
   "github.com/tastaturtier/someparts-hugo": {
     "id": 239798818,
@@ -3539,29 +3530,29 @@
   "github.com/theNewDynamic/gohugo-theme-ananke": {
     "id": 87873787,
     "created_at": "2017-04-11T01:24:05Z",
-    "updated_at": "2023-03-23T22:07:52Z",
+    "updated_at": "2023-03-27T07:14:13Z",
     "name": "gohugo-theme-ananke",
     "description": "Ananke: A theme for Hugo Sites",
     "html_url": "https://github.com/theNewDynamic/gohugo-theme-ananke",
-    "stargazers_count": 877
+    "stargazers_count": 878
   },
   "github.com/thegeeklab/hugo-geekblog": {
     "id": 275451763,
     "created_at": "2020-06-27T20:55:19Z",
-    "updated_at": "2023-03-24T23:07:49Z",
+    "updated_at": "2023-03-29T03:48:19Z",
     "name": "hugo-geekblog",
     "description": "Hugo theme made for blogs",
     "html_url": "https://github.com/thegeeklab/hugo-geekblog",
-    "stargazers_count": 82
+    "stargazers_count": 84
   },
   "github.com/thegeeklab/hugo-geekdoc": {
     "id": 231097194,
     "created_at": "2019-12-31T13:53:04Z",
-    "updated_at": "2023-03-24T08:01:45Z",
+    "updated_at": "2023-03-28T15:26:54Z",
     "name": "hugo-geekdoc",
     "description": "Hugo theme made for documentation",
     "html_url": "https://github.com/thegeeklab/hugo-geekdoc",
-    "stargazers_count": 417
+    "stargazers_count": 420
   },
   "github.com/thingsym/hugo-theme-techdoc": {
     "id": 123775108,
@@ -3701,11 +3692,11 @@
   "github.com/vaga/hugo-theme-m10c": {
     "id": 166530704,
     "created_at": "2019-01-19T09:43:35Z",
-    "updated_at": "2023-03-23T06:19:22Z",
+    "updated_at": "2023-03-29T13:07:38Z",
     "name": "hugo-theme-m10c",
     "description": "A minimalistic (m10c) blog theme for Hugo",
     "html_url": "https://github.com/vaga/hugo-theme-m10c",
-    "stargazers_count": 381
+    "stargazers_count": 379
   },
   "github.com/vantagedesign/ace-documentation": {
     "id": 235901960,
@@ -3719,11 +3710,11 @@
   "github.com/victoriadrake/hugo-theme-introduction": {
     "id": 84793453,
     "created_at": "2017-03-13T06:50:23Z",
-    "updated_at": "2023-03-25T15:38:25Z",
+    "updated_at": "2023-03-27T12:03:46Z",
     "name": "hugo-theme-introduction",
     "description": "Minimal, single page, smooth-scrolling theme for Hugo static site generator.",
     "html_url": "https://github.com/victoriadrake/hugo-theme-introduction",
-    "stargazers_count": 614
+    "stargazers_count": 615
   },
   "github.com/victoriadrake/neofeed-theme/v2": {
     "id": 327305114,
@@ -3791,11 +3782,11 @@
   "github.com/willfaught/paige": {
     "id": 533992766,
     "created_at": "2022-09-08T00:43:48Z",
-    "updated_at": "2023-03-23T07:24:15Z",
+    "updated_at": "2023-03-27T17:11:04Z",
     "name": "paige",
     "description": "Powerful, pliable pixel perfection. An advanced Hugo theme.",
     "html_url": "https://github.com/willfaught/paige",
-    "stargazers_count": 45
+    "stargazers_count": 47
   },
   "github.com/wlh320/hugo-theme-hulga": {
     "id": 312607290,
@@ -3809,20 +3800,20 @@
   "github.com/wowchemy/starter-hugo-academic": {
     "id": 111604813,
     "created_at": "2017-11-21T21:47:01Z",
-    "updated_at": "2023-03-25T11:36:18Z",
+    "updated_at": "2023-03-29T13:08:48Z",
     "name": "starter-hugo-academic",
     "description": "🎓 Hugo Academic Theme 创建一个学术网站. Easily create a beautiful academic résumé or educational website using Hugo, GitHub, and Netlify.",
     "html_url": "https://github.com/wowchemy/starter-hugo-academic",
-    "stargazers_count": 2737
+    "stargazers_count": 2741
   },
   "github.com/wowchemy/wowchemy-hugo-themes/modules/wowchemy/v5": {
     "id": 57165232,
     "created_at": "2016-04-26T22:09:15Z",
-    "updated_at": "2023-03-25T07:03:38Z",
+    "updated_at": "2023-03-29T09:43:23Z",
     "name": "wowchemy-hugo-themes",
     "description": "🔥 Hugo website builder, Hugo themes \u0026 Hugo CMS. No code, easily build with blocks! 创建在线课程，学术简历或初创网站。#OpenScience",
     "html_url": "https://github.com/wowchemy/wowchemy-hugo-themes",
-    "stargazers_count": 7094
+    "stargazers_count": 7098
   },
   "github.com/wtoll/venture": {
     "id": 374216323,
@@ -3854,11 +3845,11 @@
   "github.com/xianmin/hugo-theme-jane": {
     "id": 124070868,
     "created_at": "2018-03-06T11:48:50Z",
-    "updated_at": "2023-03-25T10:52:27Z",
+    "updated_at": "2023-03-27T03:47:56Z",
     "name": "hugo-theme-jane",
     "description": "A readable \u0026 concise theme for Hugo",
     "html_url": "https://github.com/xianmin/hugo-theme-jane",
-    "stargazers_count": 832
+    "stargazers_count": 834
   },
   "github.com/xiaoheiAh/hugo-theme-pure": {
     "id": 211669990,
@@ -3908,11 +3899,11 @@
   "github.com/yihui/hugo-xmin": {
     "id": 94504324,
     "created_at": "2017-06-16T04:13:22Z",
-    "updated_at": "2023-03-25T14:00:01Z",
+    "updated_at": "2023-03-29T00:12:50Z",
     "name": "hugo-xmin",
     "description": "eXtremely Minimal Hugo theme: about 150 lines of code in total, including HTML and CSS (with no dependencies)",
     "html_url": "https://github.com/yihui/hugo-xmin",
-    "stargazers_count": 552
+    "stargazers_count": 555
   },
   "github.com/yoshiharuyamashita/blackburn": {
     "id": 49835249,
@@ -3953,11 +3944,11 @@
   "github.com/zerostaticthemes/hugo-hero-theme": {
     "id": 160591048,
     "created_at": "2018-12-05T23:22:47Z",
-    "updated_at": "2023-03-21T03:52:41Z",
+    "updated_at": "2023-03-26T07:28:21Z",
     "name": "hugo-hero-theme",
     "description": "A multi-page Hugo theme with fullscreen hero images and fullwidth sections.",
     "html_url": "https://github.com/zerostaticthemes/hugo-hero-theme",
-    "stargazers_count": 304
+    "stargazers_count": 305
   },
   "github.com/zerostaticthemes/hugo-serif-theme": {
     "id": 159459907,
@@ -3989,11 +3980,11 @@
   "github.com/zhaohuabing/hugo-theme-cleanwhite": {
     "id": 137584400,
     "created_at": "2018-06-16T13:57:14Z",
-    "updated_at": "2023-03-21T00:27:06Z",
+    "updated_at": "2023-03-29T11:32:32Z",
     "name": "hugo-theme-cleanwhite",
     "description": "A clean, elegant blog theme for hugo",
     "html_url": "https://github.com/zhaohuabing/hugo-theme-cleanwhite",
-    "stargazers_count": 548
+    "stargazers_count": 551
   },
   "github.com/zhe/hugo-theme-slim": {
     "id": 34523524,
@@ -4007,29 +3998,29 @@
   "github.com/zjedi/hugo-scroll": {
     "id": 277762663,
     "created_at": "2020-07-07T08:37:56Z",
-    "updated_at": "2023-03-24T20:50:01Z",
+    "updated_at": "2023-03-27T19:36:52Z",
     "name": "hugo-scroll",
     "description": "📜 A Hugo theme for pretty, quick and simple single-page websites.",
     "html_url": "https://github.com/zjedi/hugo-scroll",
-    "stargazers_count": 199
+    "stargazers_count": 201
   },
   "github.com/zwbetz-gh/cayman-hugo-theme": {
     "id": 177856819,
     "created_at": "2019-03-26T19:37:52Z",
-    "updated_at": "2023-02-08T16:05:43Z",
+    "updated_at": "2023-03-26T15:51:50Z",
     "name": "cayman-hugo-theme",
     "description": "Cayman is a clean, responsive theme for Hugo, ported from the original Jekyll Cayman Theme.",
     "html_url": "https://github.com/zwbetz-gh/cayman-hugo-theme",
-    "stargazers_count": 41
+    "stargazers_count": 40
   },
   "github.com/zwbetz-gh/cupper-hugo-theme": {
     "id": 168213023,
     "created_at": "2019-01-29T19:16:57Z",
-    "updated_at": "2023-03-08T05:54:45Z",
+    "updated_at": "2023-03-26T15:56:11Z",
     "name": "cupper-hugo-theme",
     "description": "An accessibility-friendly Hugo theme, ported from the original Cupper project.",
     "html_url": "https://github.com/zwbetz-gh/cupper-hugo-theme",
-    "stargazers_count": 275
+    "stargazers_count": 276
   },
   "github.com/zwbetz-gh/minimal-bootstrap-hugo-theme": {
     "id": 152019350,

--- a/cmd/hugothemesitebuilder/build/config.json
+++ b/cmd/hugothemesitebuilder/build/config.json
@@ -1202,11 +1202,6 @@
       {
         "ignoreImports": true,
         "noMounts": true,
-        "path": "github.com/lukeorth/poison"
-      },
-      {
-        "ignoreImports": true,
-        "noMounts": true,
         "path": "github.com/lxndrblz/anatole"
       },
       {

--- a/cmd/hugothemesitebuilder/build/go.mod
+++ b/cmd/hugothemesitebuilder/build/go.mod
@@ -363,7 +363,7 @@ require (
 	github.com/samrobbins85/hugo-developer-portfolio v0.0.0-20221230201635-d7e23c1c723e // indirect
 	github.com/sbruder/spectral v0.0.0-20230306171048-8463c525fb19 // indirect
 	github.com/schmanat/hugo-highlights-theme v0.0.0-20200409134000-79eb66a32c74 // indirect
-	github.com/schnerring/hugo-theme-gruvbox v0.0.0-20230329002402-4028095875eb // indirect
+	github.com/schnerring/hugo-theme-gruvbox v0.0.0-20230329014622-49b2b3e0b542 // indirect
 	github.com/schollz/onetwothree v0.0.0-20190916161743-a09e6530494c // indirect
 	github.com/seanlane/gochowdown v0.0.0-20220603122033-5458dc7bd80a // indirect
 	github.com/sefeng211/techlab-hugo-theme v0.0.0-20221108011911-ed0fcb80d48f // indirect

--- a/cmd/hugothemesitebuilder/build/go.sum
+++ b/cmd/hugothemesitebuilder/build/go.sum
@@ -770,6 +770,8 @@ github.com/schnerring/hugo-theme-gruvbox v0.0.0-20230325155807-531343fb4968 h1:n
 github.com/schnerring/hugo-theme-gruvbox v0.0.0-20230325155807-531343fb4968/go.mod h1:Wk0pPM7AitTax6Qn5mukgvFOIjRPB2/cTaV/pAXiA2Q=
 github.com/schnerring/hugo-theme-gruvbox v0.0.0-20230329002402-4028095875eb h1:k4ETBcWLFf+YiSpAqiZ3wC2IfQit7PgpVXU3ssXza4g=
 github.com/schnerring/hugo-theme-gruvbox v0.0.0-20230329002402-4028095875eb/go.mod h1:Wk0pPM7AitTax6Qn5mukgvFOIjRPB2/cTaV/pAXiA2Q=
+github.com/schnerring/hugo-theme-gruvbox v0.0.0-20230329014622-49b2b3e0b542 h1:taOYCFHTJaufoznI3ACdYr/e2AKRSkV0NrVgF1VfGqw=
+github.com/schnerring/hugo-theme-gruvbox v0.0.0-20230329014622-49b2b3e0b542/go.mod h1:2s8YIdWs0I+gUl08QnNC+bRgpw5n6btEu3Eap8ZC1ms=
 github.com/schollz/onetwothree v0.0.0-20190916161743-a09e6530494c h1:503PXSWQR7gXGemoNiHnFz76i8pLEgTF0tLDnBIU9DQ=
 github.com/schollz/onetwothree v0.0.0-20190916161743-a09e6530494c/go.mod h1:7GFph1UoE8pGK7EBI8rJLnfsBltHgQp0gb8VIBZoTOI=
 github.com/seanlane/gochowdown v0.0.0-20220603122033-5458dc7bd80a h1:ZnCjJaq/MoQv0fOo6L7eZvjhlwC/+IcSF1dJGeoRRRM=

--- a/themes.txt
+++ b/themes.txt
@@ -237,7 +237,6 @@ github.com/loveminimal/hugo-theme-virgo
 github.com/lubang/hugo-hello-programmer-theme
 github.com/luizdepra/hugo-coder
 github.com/LukasJoswiak/etch
-github.com/lukeorth/poison
 github.com/lxndrblz/anatole
 github.com/M1cR0xf7/kaslaanka
 github.com/marcanuy/simpleit-hugo-theme


### PR DESCRIPTION
https://github.com/actions/checkout/releases

https://github.com/gohugoio/hugoThemesSiteBuilder/actions/runs/4516409153

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.