### PR TITLE
Add github reference (adritian)

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -435,6 +435,7 @@ github.com/your-identity/hugo-theme-dimension
 github.com/yue1124/hero
 github.com/Yukuro/hugo-theme-shell
 github.com/yursan9/manis-hugo-theme
+github.com/zetxek/adritian-free-hugo-theme
 github.com/zerostaticthemes/hugo-hero-theme
 github.com/zerostaticthemes/hugo-serif-theme
 github.com/zerostaticthemes/hugo-whisper-theme


### PR DESCRIPTION
Add theme adritian for Hugo. Fork of Raditian (https://github.com/radity/raditian-free-hugo-theme).

Demo site: https://www.adrianmoreno.info/
Github Repo: https://github.com/zetxek/adritian-free-hugo-theme

The changes from the original theme consist mainly on technical updates: upgrade from bootstrap v4 to v5, removing jQuery as a dependency, and editing templates to make them more accessible.