### PR TITLE
Remove github.com/Y4er/hugo-theme-easybook from other places

### DIFF
--- a/cmd/hugothemesitebuilder/build/cache/0000.githubrepos.json
+++ b/cmd/hugothemesitebuilder/build/cache/0000.githubrepos.json
@@ -566,15 +566,6 @@
     "html_url": "https://github.com/Xzya/hugo-material-blog",
     "stargazers_count": 22
   },
-  "github.com/Y4er/hugo-theme-easybook": {
-    "id": 212960032,
-    "created_at": "2019-10-05T07:19:06Z",
-    "updated_at": "2023-01-21T06:27:40Z",
-    "name": "hugo-theme-easybook",
-    "description": "🚀 A super concise theme for Hugo",
-    "html_url": "https://github.com/Y4er/hugo-theme-easybook",
-    "stargazers_count": 8
-  },
   "github.com/Yukuro/hugo-theme-shell": {
     "id": 386575752,
     "created_at": "2021-07-16T09:05:19Z",

--- a/cmd/hugothemesitebuilder/build/config.json
+++ b/cmd/hugothemesitebuilder/build/config.json
@@ -2147,11 +2147,6 @@
       {
         "ignoreImports": true,
         "noMounts": true,
-        "path": "github.com/Y4er/hugo-theme-easybook"
-      },
-      {
-        "ignoreImports": true,
-        "noMounts": true,
         "path": "github.com/yanlinlin82/simple-style"
       },
       {

--- a/cmd/hugothemesitebuilder/build/go.mod
+++ b/cmd/hugothemesitebuilder/build/go.mod
@@ -66,7 +66,6 @@ require (
 	github.com/Vimux/mainroad v0.0.0-20230416094851-6d2e50083f25 // indirect
 	github.com/WingLim/hugo-tania v1.9.3 // indirect
 	github.com/Xzya/hugo-material-blog v0.100.2 // indirect
-	github.com/Y4er/hugo-theme-easybook v0.0.0-20200124093729-48555b802349 // indirect
 	github.com/Yukuro/hugo-theme-shell v0.1.5 // indirect
 	github.com/aanupam23/hugo-sugoi v0.6.0 // indirect
 	github.com/achary/engimo v2.10.1+incompatible // indirect


### PR DESCRIPTION
## Attempt to fix CI

I had removed github.com/Y4er/hugo-theme-easybook theme from `themes.txt`.

This doesn't seem to fix the CI. The most recent [run](https://github.com/gohugoio/hugoThemesSiteBuilder/actions/runs/4760067041) of GitHub action has failed again due to this theme.

So, I am removing this theme from other places(files).