### PR TITLE
Add adityatelange/hugo-index

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -8,6 +8,7 @@ github.com/526avijitgupta/gokarna
 github.com/7ma7X/HugoTeX
 github.com/aanupam23/hugo-sugoi
 github.com/achary/engimo
+github.com/adityatelange/hugo-index
 github.com/adityatelange/hugo-PaperMod
 github.com/aerohub/hugo-faq-theme
 github.com/aerohub/hugo-identity-theme


### PR DESCRIPTION
This PR adds https://github.com/adityatelange/hugo-index to hugoThemesSiteBuilder

Demo: https://adityatelange.github.io/hugo-index/

![](https://user-images.githubusercontent.com/21258296/233713549-07016736-3ca1-46a3-895f-9c08b6cd9145.png)