### PR TITLE
Remove github.com/Track3/hermit theme

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -397,7 +397,6 @@ github.com/thomasheller/crab
 github.com/tnwhitwell/hugo-startpage-theme
 github.com/tohn/linkshrubbery
 github.com/tosi29/inkblotty
-github.com/Track3/hermit
 github.com/tummychow/lanyon-hugo
 github.com/tylerjlawson/port-hugo
 github.com/tylerjlawson/simple-resume


### PR DESCRIPTION
@bep, 

1. Shall we remove https://github.com/Track3/hermit theme from the list? This theme was last updated in 2020.

2. Can we arrive at a distinct number, instead of 'past few years' (see the lines from README below)? Then it will be easy to point out outdated themes.
https://github.com/gohugoio/hugoThemesSiteBuilder/blob/4cab60a42dccfd1ba735fc5b578c1422194af9db/README.md?plain=1#L146-L149
