### PR TITLE
fix: remove Hinode theme to fix ci errors

### DIFF
--- a/cmd/hugothemesitebuilder/build/cache/0000.githubrepos.json
+++ b/cmd/hugothemesitebuilder/build/cache/0000.githubrepos.json
@@ -2438,15 +2438,6 @@
     "html_url": "https://github.com/marcanuy/simpleit-hugo-theme",
     "stargazers_count": 17
   },
-  "github.com/markdumay/hugo-theme-hinode": {
-    "id": 447086741,
-    "created_at": "2022-01-12T05:20:40Z",
-    "updated_at": "2023-03-27T15:50:35Z",
-    "name": "hinode",
-    "description": "A clean documentation and blog theme for your Hugo site based on Bootstrap 5",
-    "html_url": "https://github.com/gethinode/hinode",
-    "stargazers_count": 28
-  },
   "github.com/marketempower/axiom": {
     "id": 256073917,
     "created_at": "2020-04-16T01:02:50Z",

--- a/cmd/hugothemesitebuilder/build/config.json
+++ b/cmd/hugothemesitebuilder/build/config.json
@@ -1222,11 +1222,6 @@
       {
         "ignoreImports": true,
         "noMounts": true,
-        "path": "github.com/markdumay/hugo-theme-hinode"
-      },
-      {
-        "ignoreImports": true,
-        "noMounts": true,
         "path": "github.com/marketempower/axiom"
       },
       {

--- a/cmd/hugothemesitebuilder/build/go.mod
+++ b/cmd/hugothemesitebuilder/build/go.mod
@@ -274,7 +274,6 @@ require (
 	github.com/luizdepra/hugo-coder v0.0.0-20230713135121-c3df12d0bbc2 // indirect
 	github.com/lxndrblz/anatole v1.13.0 // indirect
 	github.com/marcanuy/simpleit-hugo-theme v0.0.0-20210616134837-49277e5c3be0 // indirect
-	github.com/markdumay/hugo-theme-hinode v0.15.5 // indirect
 	github.com/marketempower/axiom v0.8.0 // indirect
 	github.com/matcornic/hugo-theme-learn v0.0.0-20211028190410-e817f53d690d // indirect
 	github.com/matsuyoshi30/harbor v1.0.0 // indirect


### PR DESCRIPTION
## What?
Remove `github.com/markdumay/hugo-theme-hinode` from `themes.txt` and cache to fix ci errors.

## Why?
The author of Hinode theme changed the theme's repo from `github.com/markdumay/hugo-theme-hinode` to`github.com/gethinode/hinode`. This created issues with Go mudules and thus the CI failed.