### PR TITLE
fix: upgrade Go version to fix Netlify deploy issue, closes #340

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,11 +4,11 @@
     command = "./build.sh"
     ignore  = "/bin/false"
 
-[context.production.environment]
-    HUGO_VERSION = "0.110.0"
+# No need to specify environment variables for each context (production, deploy-preview & branch-deploy).
+# From https://docs.netlify.com/configure-builds/file-based-configuration/#deploy-contexts
+#   any property of a context-aware key, such as [build] or [[plugins]], will be applied to all contexts 
+#   unless the same property key is present in a more specific context.
 
-[context.deploy-preview.environment]
-    HUGO_VERSION = "0.110.0"
-
-[context.branch-deploy.environment]
-    HUGO_VERSION = "0.110.0"
+[build.environment]
+  HUGO_VERSION = "0.117.0"
+  GO_VERSION = "1.21.0"


### PR DESCRIPTION
## What does this PR do?

Upgrades the version of Go used for Netlify build, with an aim to fix #340.

## Explanation

### Why did the deploy fail?

From Netlify [log](https://app.netlify.com/sites/hugothemes/deploys/64ed6fc01f503e000803d354#L66-L69):

```shell
9:48:39 AM: go: errors parsing go.mod:
9:48:39 AM: /opt/build/repo/cmd/hugothemesitebuilder/build/go.mod:5: unknown directive: toolchain
9:48:39 AM: Error: failed to download modules: failed to execute 'go [mod download]': failed to execute binary go with args [mod download]: go: errors parsing go.mod:
9:48:39 AM: /opt/build/repo/cmd/hugothemesitebuilder/build/go.mod:5: unknown directive: toolchain
```

Indeed in line no. 5,  the `go.mod` file has a new directive `toolchain go1.21.0 ` which was not present earlier:

https://github.com/gohugoio/hugoThemesSiteBuilder/blob/2a4376c6e4c044d6d9fdc39907861ea64ba6fe5b/cmd/hugothemesitebuilder/build/go.mod#L3-L6

### How did `go.mod` file get the new directive `toolchain go1.21.0 `?

This directive was added to the `go.mod` file in commit https://github.com/gohugoio/hugoThemesSiteBuilder/commit/2a4376c6e4c044d6d9fdc39907861ea64ba6fe5b. This commit was created during GitHub action workflow run. 

#### Why was the new new directive added?

From https://go.dev/doc/toolchain : 

>Starting in Go 1.21, the Go distribution consists of a go command and a bundled Go toolchain, which is the standard library as well as the compiler, assembler, and other tools. The go command can use its bundled Go toolchain as well as other versions that it finds in the local PATH or downloads as needed.

>The choice of Go toolchain being used depends on the GOTOOLCHAIN environment setting and the go and toolchain lines in the main module’s go.mod file or the current workspace’s go.work file. As you move between different main modules and workspaces, the toolchain version being used can vary, just as module dependency versions do.

### What's the catch?

Go version `1.21.0`, was used in the GitHub action workflow as seen [here](https://github.com/gohugoio/hugoThemesSiteBuilder/actions/runs/6006329793/job/16290673133#step:3:11). This is perfectly fine since  `actions/setup-go@v3`  is setup to use `go-version: "^1.19.5"`.

https://github.com/gohugoio/hugoThemesSiteBuilder/blob/2a4376c6e4c044d6d9fdc39907861ea64ba6fe5b/.github/workflows/update-themes.yml#L13-L15

But since there was no mention of Go version in the `netlify.toml`, Go `1.19` (default as of now) was used while deploying the site on Netlify. This can be seen from the [log](https://app.netlify.com/sites/hugothemes/deploys/64ed6fc01f503e000803d354#L23): 

```shell
9:48:33 AM: go version go1.19 linux/amd64
```

Thus I feel, upgrading the Go version on Netlify could fix this issue.
