### PR TITLE
Update theme path for the Bilberry Hugo theme v4

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -31,7 +31,7 @@ github.com/J-Siu/hugo-theme-sk3
 github.com/Jack-alope/sourgough-starter
 github.com/JingWangTW/dark-theme-editor
 github.com/KatamariJr/split-landing
-github.com/Lednerb/bilberry-hugo-theme/v3
+github.com/Lednerb/bilberry-hugo-theme/v4
 github.com/LordMathis/hugo-theme-nightfall
 github.com/LordMathis/hugo-theme-nix
 github.com/LucasVadilho/heyo-hugo-theme


### PR DESCRIPTION
The latest version of the Bilberry Hugo theme is [v4](https://github.com/Lednerb/bilberry-hugo-theme/releases/tag/v4.0.5), therefore, its theme path should be updated.