### PR TITLE
fix(hash mismatch): temporarily remove hugo-toigian theme

### DIFF
--- a/cmd/hugothemesitebuilder/build/cache/0000.githubrepos.json
+++ b/cmd/hugothemesitebuilder/build/cache/0000.githubrepos.json
@@ -2879,15 +2879,6 @@
     "html_url": "https://github.com/ntk148v/hugo-cuisine-book",
     "stargazers_count": 9
   },
-  "github.com/ntk148v/hugo-toigian": {
-    "id": 554670757,
-    "created_at": "2022-10-20T07:34:10Z",
-    "updated_at": "2023-08-28T03:36:57Z",
-    "name": "hugo-toigian",
-    "description": "A minimal Hugo theme with Tailwind CSS that covers all of the essentials. All you have to do is start typing!",
-    "html_url": "https://github.com/ntk148v/hugo-toigian",
-    "stargazers_count": 27
-  },
   "github.com/nunocoracao/blowfish/v2": {
     "id": 534798642,
     "created_at": "2022-09-09T20:38:52Z",

--- a/cmd/hugothemesitebuilder/build/config.json
+++ b/cmd/hugothemesitebuilder/build/config.json
@@ -1602,11 +1602,6 @@
       {
         "ignoreImports": true,
         "noMounts": true,
-        "path": "github.com/ntk148v/hugo-toigian"
-      },
-      {
-        "ignoreImports": true,
-        "noMounts": true,
         "path": "github.com/nunocoracao/blowfish/v2"
       },
       {

--- a/cmd/hugothemesitebuilder/build/go.mod
+++ b/cmd/hugothemesitebuilder/build/go.mod
@@ -326,7 +326,6 @@ require (
 	github.com/nixentric/Lowkey-Hugo-Theme v0.0.0-20230919154918-aa01db51e69f // indirect
 	github.com/nodejh/hugo-theme-cactus-plus v0.0.0-20230717024722-c6ce39c13659 // indirect
 	github.com/ntk148v/hugo-cuisine-book v0.0.0-20230914083228-188f158ad681 // indirect
-	github.com/ntk148v/hugo-toigian v0.0.2 // indirect
 	github.com/nunocoracao/blowfish v1.9.0 // indirect
 	github.com/nunocoracao/blowfish/v2 v2.40.1 // indirect
 	github.com/nurlansu/hugo-sustain v0.0.0-20230524192148-21d9f8f53692 // indirect


### PR DESCRIPTION
From Netlify log:
```
2:57:38 PM: verifying github.com/ntk148v/hugo-toigian@v0.0.2: checksum mismatch 2:57:38 PM: 	downloaded: h1:kWbaK5JXp1sIqzOsrcS6cWw+OlzMjaFOIH1ZLsIu99g=
2:57:38 PM: 	go.sum:     h1:8Vy+1nQCgKgr9aDFZ4pAUjp0sVE/ZzXgsRrqCYehuaA=
2:57:38 PM: SECURITY ERROR
2:57:38 PM: This download does NOT match an earlier download recorded in go.sum.
```