### PR TITLE
Update congo theme module version

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -215,7 +215,7 @@ github.com/joseph-mccarthy/hugo-bootstrap-freelancer-template
 github.com/josephhutch/aether
 github.com/jota-ele-ene/just-me
 github.com/joway/hugo-theme-yinyang
-github.com/jpanther/congo
+github.com/jpanther/congo/v2
 github.com/jpanther/lynx
 github.com/jpescador/hugo-future-imperfect
 github.com/jrutheiser/hugo-lithium-theme


### PR DESCRIPTION
It looks like my theme was delisted because it hasn't detected the latest version correctly. I've bumped the go module version in `themes.txt` so hopefully this will fix the issue.