### PR TITLE
Fix `Toha` theme URL

### DIFF
--- a/cmd/hugothemesitebuilder/build/config.json
+++ b/cmd/hugothemesitebuilder/build/config.json
@@ -1010,7 +1010,7 @@
         "ignoreConfig": true,
         "ignoreImports": true,
         "noMounts": true,
-        "path": "github.com/hossainemruz/toha"
+        "path": "github.com/hugo-toha/toha/v4"
       },
       {
         "ignoreConfig": true,

--- a/cmd/hugothemesitebuilder/build/go.mod
+++ b/cmd/hugothemesitebuilder/build/go.mod
@@ -227,6 +227,7 @@ require (
 	github.com/hugo-fixit/FixIt v0.3.1 // indirect
 	github.com/hugo-next/hugo-theme-next v4.5.3+incompatible // indirect
 	github.com/hugo-sid/hugo-blog-awesome v1.13.0 // indirect
+	github.com/hugo-toha/toha/v4 v4.2.0 // indirect
 	github.com/humrochagf/colordrop v1.12.1 // indirect
 	github.com/huyb1991/hugo-lamp v1.2.1 // indirect
 	github.com/iCyris/hugo-theme-yuki v1.1.0 // indirect

--- a/themes.txt
+++ b/themes.txt
@@ -165,7 +165,7 @@ github.com/heyeshuang/hugo-theme-tokiwa
 github.com/hivickylai/hugo-theme-sam
 github.com/homecat805/hugo-theme-walden
 github.com/hootan09/simple-cv
-github.com/hossainemruz/toha
+github.com/hugo-toha/toha/v4
 github.com/hotjuicew/hugo-JuiceBar
 github.com/httpsecure/hugo-cat
 github.com/httpsecure/hugo-theme-red-rose


### PR DESCRIPTION
I have moved the `Toha` theme to its dedicated GitHub org [hugo-toha/toha](https://github.com/hugo-toha/toha). I have also updated my go module to `v4`. As a result, the theme builder is not detecting newer changes. This PR will solve that issue.