### PR TITLE
ci: remove theme from go.mod

### DIFF
--- a/cmd/hugothemesitebuilder/build/cache/githubrepos.json
+++ b/cmd/hugothemesitebuilder/build/cache/githubrepos.json
@@ -1466,15 +1466,6 @@
     "html_url": "https://github.com/dldx/hpstr-hugo-theme",
     "stargazers_count": 19
   },
-  "github.com/dmachard/hugo-theme-gists": {
-    "id": 692517927,
-    "created_at": "2023-09-16T18:13:02Z",
-    "updated_at": "2024-01-20T13:30:34Z",
-    "name": "hugo-theme-gists",
-    "description": "A minimalist gists blog theme for Hugo, inspired by Github.",
-    "html_url": "https://github.com/dmachard/hugo-theme-gists",
-    "stargazers_count": 5
-  },
   "github.com/docura/docura": {
     "id": 532579508,
     "created_at": "2022-09-04T15:28:18Z",

--- a/cmd/hugothemesitebuilder/build/config.json
+++ b/cmd/hugothemesitebuilder/build/config.json
@@ -650,12 +650,6 @@
         "ignoreConfig": true,
         "ignoreImports": true,
         "noMounts": true,
-        "path": "github.com/dmachard/hugo-theme-gists"
-      },
-      {
-        "ignoreConfig": true,
-        "ignoreImports": true,
-        "noMounts": true,
         "path": "github.com/docura/docura"
       },
       {

--- a/cmd/hugothemesitebuilder/build/go.mod
+++ b/cmd/hugothemesitebuilder/build/go.mod
@@ -166,7 +166,6 @@ require (
 	github.com/diwao/hestia-pure v0.0.0-20180322071727-320c944ffcf9 // indirect
 	github.com/djuelg/Shapez-Theme v0.0.0-20200822131204-bfc2adf16fd4 // indirect
 	github.com/dldx/hpstr-hugo-theme v0.0.0-20180623041957-3658a0b0c9c2 // indirect
-	github.com/dmachard/hugo-theme-gists v1.0.0 // indirect
 	github.com/docura/docura v0.0.0-20231109095615-5c14e0106140 // indirect
 	github.com/dplesca/purehugo v0.0.0-20190924072610-5b577adff2e1 // indirect
 	github.com/dsrkafuu/hugo-theme-fuji v2.8.2+incompatible // indirect

--- a/themes.txt
+++ b/themes.txt
@@ -105,7 +105,6 @@ github.com/dillonzq/LoveIt
 github.com/diwao/hestia-pure
 github.com/djuelg/Shapez-Theme
 github.com/dldx/hpstr-hugo-theme
-github.com/dmachard/hugo-theme-gists
 github.com/docura/docura
 github.com/dplesca/purehugo
 github.com/dsrkafuu/hugo-theme-fuji


### PR DESCRIPTION
Temporarily remove `hugo-theme-gists theme` to fix Netlify deploy