### PR TITLE
Update repository for `Toha` theme

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -165,7 +165,6 @@ github.com/heyeshuang/hugo-theme-tokiwa
 github.com/hivickylai/hugo-theme-sam
 github.com/homecat805/hugo-theme-walden
 github.com/hootan09/simple-cv
-github.com/hossainemruz/toha
 github.com/hotjuicew/hugo-JuiceBar
 github.com/httpsecure/hugo-cat
 github.com/httpsecure/hugo-theme-red-rose
@@ -174,6 +173,7 @@ github.com/hugcis/hugo-astatine-theme
 github.com/hugo-fixit/FixIt
 github.com/hugo-next/hugo-theme-next
 github.com/hugo-sid/hugo-blog-awesome
+github.com/hugo-toha/toha/v4
 github.com/HugoBlox/hugo-blox-builder/modules/blox-tailwind
 github.com/HugoBlox/theme-academic-cv
 github.com/humrochagf/colordrop


### PR DESCRIPTION
I have moved the `Toha` theme to its dedicated GitHub org [hugo-toha/toha](https://github.com/hugo-toha/toha). I have also updated my go module to `v4`. As a result, the theme builder is not detecting newer changes. This PR will solve that issue.