### PR TITLE
ci(GitHub action): bump actions/checkout to v4 & actions/setup-go to v5

### DIFF
--- a/.github/workflows/update-themes.yml
+++ b/.github/workflows/update-themes.yml
@@ -12,8 +12,8 @@ jobs:
       HUGO_CACHEDIR: /tmp/hugo_cache
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "^1.21.0"
       - name: Update submodules

--- a/.github/workflows/update-themes.yml
+++ b/.github/workflows/update-themes.yml
@@ -8,6 +8,10 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Use bash shell for all steps in the workflow
+    defaults:
+      run:
+        shell: bash
     env:
       HUGO_CACHEDIR: /tmp/hugo_cache
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -17,16 +21,22 @@ jobs:
         with:
           go-version: "^1.21.0"
       - name: Update submodules
-        shell: bash
         working-directory: ./cmd/hugothemesitebuilder
         run: |
-          git config --global user.email "bep@users.noreply.github.com"
-          git config --global user.name "bep"
           go install github.com/gohugoio/hugo@${{ env.HUGO_VERSION }}
           go run main.go build -skipSiteBuild -cleanCache
           cd build
           hugo mod get
           hugo mod tidy
+      - name: Commit & push changes
+        # Check the github.ref context to determine the current branch name. if it is 'refs/heads/main', then commit and push the changes.
+        # This allows experimenting/debugging GitHub actions without concerns about committing changes.
+        # For example, changes can be made to this workflow in a separate branch and a workflow run can be triggered manually (workflow_dispatch).
+        # For more information, see https://docs.github.com/en/actions/learn-github-actions/contexts
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          git config --global user.email "bep@users.noreply.github.com"
+          git config --global user.name "bep"
           git add .
           git commit -am "[Bot] Update themes"
           git push --force-with-lease

--- a/cmd/hugothemesitebuilder/build/cache/githubrepos.json
+++ b/cmd/hugothemesitebuilder/build/cache/githubrepos.json
@@ -2267,15 +2267,6 @@
     "html_url": "https://github.com/jonathanjanssens/hugo-casper3",
     "stargazers_count": 57
   },
-  "github.com/joseph-mccarthy/hugo-bootstrap-freelancer-template": {
-    "id": 458968701,
-    "created_at": "2022-02-14T00:33:19Z",
-    "updated_at": "2023-11-27T10:33:28Z",
-    "name": "hugo-bootstrap-freelancer-template",
-    "description": "Hugo Bootstrap Freelancer Theme. Based on the startBootStrap Freelancer theme.",
-    "html_url": "https://github.com/joseph-mccarthy/hugo-bootstrap-freelancer-template",
-    "stargazers_count": 5
-  },
   "github.com/josephhutch/aether": {
     "id": 125391209,
     "created_at": "2018-03-15T15:52:42Z",

--- a/cmd/hugothemesitebuilder/build/cache/githubrepos.json
+++ b/cmd/hugothemesitebuilder/build/cache/githubrepos.json
@@ -3572,15 +3572,6 @@
     "html_url": "https://github.com/shaform/hugo-theme-den",
     "stargazers_count": 44
   },
-  "github.com/shenoybr/hugo-goa": {
-    "id": 70299290,
-    "created_at": "2016-10-08T02:59:24Z",
-    "updated_at": "2024-02-01T03:02:16Z",
-    "name": "hugo-goa",
-    "description": "Simple Minimalistic Theme for Hugo",
-    "html_url": "https://github.com/kaapiandcode/hugo-goa",
-    "stargazers_count": 258
-  },
   "github.com/siegerts/hugo-theme-basic": {
     "id": 168743880,
     "created_at": "2019-02-01T18:42:50Z",

--- a/cmd/hugothemesitebuilder/build/config.json
+++ b/cmd/hugothemesitebuilder/build/config.json
@@ -2294,12 +2294,6 @@
         "ignoreConfig": true,
         "ignoreImports": true,
         "noMounts": true,
-        "path": "github.com/shenoybr/hugo-goa"
-      },
-      {
-        "ignoreConfig": true,
-        "ignoreImports": true,
-        "noMounts": true,
         "path": "github.com/siegerts/hugo-theme-basic"
       },
       {

--- a/cmd/hugothemesitebuilder/build/config.json
+++ b/cmd/hugothemesitebuilder/build/config.json
@@ -1286,12 +1286,6 @@
         "ignoreConfig": true,
         "ignoreImports": true,
         "noMounts": true,
-        "path": "github.com/joseph-mccarthy/hugo-bootstrap-freelancer-template"
-      },
-      {
-        "ignoreConfig": true,
-        "ignoreImports": true,
-        "noMounts": true,
         "path": "github.com/josephhutch/aether"
       },
       {

--- a/cmd/hugothemesitebuilder/build/go.mod
+++ b/cmd/hugothemesitebuilder/build/go.mod
@@ -400,7 +400,6 @@ require (
 	github.com/serkodev/holy v0.0.0-20230619092132-813c12d1d9ad // indirect
 	github.com/setsevireon/photophobia v0.1.2 // indirect
 	github.com/shaform/hugo-theme-den v0.0.0-20220704130400-f420b491a016 // indirect
-	github.com/shenoybr/hugo-goa v0.0.0-20240215105909-bc81702b8241 // indirect
 	github.com/siegerts/hugo-theme-basic v0.0.0-20200521131547-7f8226c418da // indirect
 	github.com/sieis/re-cover v0.0.0-20230906184022-350819ec15eb // indirect
 	github.com/slashformotion/hugo-tufte v0.2.0 // indirect

--- a/cmd/hugothemesitebuilder/build/go.mod
+++ b/cmd/hugothemesitebuilder/build/go.mod
@@ -255,7 +255,6 @@ require (
 	github.com/jnjosh/internet-weblog v0.0.0-20240104001134-830ad5392bf0 // indirect
 	github.com/joeroe/risotto v0.4.0 // indirect
 	github.com/jonathanjanssens/hugo-casper3 v1.0.1 // indirect
-	github.com/joseph-mccarthy/hugo-bootstrap-freelancer-template v1.0.2 // indirect
 	github.com/josephhutch/aether v0.0.0-20230106155952-cfba21de2f57 // indirect
 	github.com/jota-ele-ene/just-me v0.0.0-20221125102733-2ce1d38b8ea3 // indirect
 	github.com/joway/hugo-theme-yinyang v0.0.0-20220428055119-1c3bec670a42 // indirect

--- a/themes.txt
+++ b/themes.txt
@@ -377,7 +377,6 @@ github.com/sergiobarriel/tophat-theme
 github.com/serkodev/holy
 github.com/setsevireon/photophobia
 github.com/shaform/hugo-theme-den
-github.com/shenoybr/hugo-goa
 github.com/siegerts/hugo-theme-basic
 github.com/sieis/re-cover
 github.com/slashformotion/hugo-tufte


### PR DESCRIPTION
## What does this PR do?

- There is a waning seen in several GitHub action logs:
  > Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-go@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

    This PR upgrades actions/checkout to v4 & actions/setup-go to v5 to eliminate this warning.
- The GitHub action run has failed due to various reasons in the past. This PR moves the 'committing' changes to a separate step. As of this PR, changes are committed only if workflow is run from main branch. This allows experimenting/debugging GitHub actions (specifically the `Update submodules` step) without concerns about committing changes.
- Removes 1 theme which is causing the GitHub action to fail. Fixes https://github.com/gohugoio/hugoThemesSiteBuilder/issues/402 .