### PR TITLE
chore: remove archived themes/repositories

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -445,7 +445,6 @@ github.com/willfaught/paige
 github.com/WingLim/hugo-tania
 github.com/Wivik/am-writing-hugo-theme
 github.com/Wivik/vinyl-records-collection-theme
-github.com/wjh18/hugo-liftoff/v3
 github.com/wlh320/hugo-theme-hulga
 github.com/wtoll/venture
 github.com/xaprb/story

--- a/themes.txt
+++ b/themes.txt
@@ -51,7 +51,6 @@ github.com/binokochumolvarghese/lightbi-hugo
 github.com/bjacquemet/personal-web
 github.com/blankoworld/hugo_theme_adam_eve
 github.com/Bonzdev/alexa-portfolio
-github.com/boratanrikulu/eternity
 github.com/bowman2001/perplex
 github.com/brianreumere/plague
 github.com/brycematheson/allegiant
@@ -144,7 +143,6 @@ github.com/gethinode/hinode
 github.com/gethyas/doks
 github.com/gevhaz/hugo-theme-notrack
 github.com/gizak/nofancy
-github.com/gkmngrgn/hugo-alageek-theme
 github.com/gonnux/hugo-apps-theme
 github.com/goodroot/hugo-classic
 github.com/google/docsy
@@ -212,7 +210,6 @@ github.com/jmau111/hugo-theme-ava
 github.com/jnjosh/internet-weblog
 github.com/joeroe/risotto
 github.com/jonathanjanssens/hugo-casper3
-github.com/joseph-mccarthy/hugo-bootstrap-freelancer-template
 github.com/josephhutch/aether
 github.com/jota-ele-ene/just-me
 github.com/joway/hugo-theme-yinyang
@@ -251,7 +248,6 @@ github.com/leonardofaria/bento
 github.com/leonhe/hugo_eiio
 github.com/leonstafford/accessible-minimalism-hugo-theme
 github.com/letItCurl/minimal_marketing
-github.com/lgaida/mediumish-gohugo-theme
 github.com/lingxz/er
 github.com/liuzc/LeaveIt
 github.com/LordMathis/hugo-theme-nightfall
@@ -272,7 +268,6 @@ github.com/marcanuy/simpleit-hugo-theme
 github.com/MarcusVirg/forty
 github.com/marketempower/axiom
 github.com/Masellum/hugo-theme-nostyleplease
-github.com/matcornic/hugo-theme-learn
 github.com/matsuyoshi30/harbor
 github.com/mattbutton/silhouette-hugo
 github.com/mattstratton/castanet
@@ -290,7 +285,6 @@ github.com/michimani/simplog
 github.com/miguelsimoni/hugo-initio
 github.com/mikeblum/hugo-now
 github.com/mismith0227/hugo_theme_pickles
-github.com/Mitrichius/hugo-theme-anubis
 github.com/mivinci/hugo-theme-minima
 github.com/mmrath/hugo-bootstrap
 github.com/monkeyWzr/hugo-theme-cactus
@@ -303,7 +297,6 @@ github.com/nanxstats/hugo-tanka
 github.com/naro143/hugo-coder-portfolio
 github.com/natarajmb/charaka-hugo-theme
 github.com/nathancday/min_night
-github.com/negrel/hugo-theme-pico
 github.com/nicokaiser/hugo-theme-gallery
 github.com/Nigh/tinyworks
 github.com/nightswinger/hugo-theme-coyote
@@ -326,7 +319,6 @@ github.com/opera7133/tella
 github.com/opera7133/vnovel
 github.com/orf/bare-hugo-theme
 github.com/pacollins/calligraphy
-github.com/panr/hugo-theme-hello-friend
 github.com/panr/hugo-theme-terminal
 github.com/parsiya/Hugo-Octopress
 github.com/paulmartins/hugo-digital-garden-theme
@@ -480,11 +472,6 @@ github.com/zetxek/adritian-free-hugo-theme
 github.com/zhaohuabing/hugo-theme-cleanwhite
 github.com/zhe/hugo-theme-slim
 github.com/zjedi/hugo-scroll
-github.com/zwbetz-gh/cayman-hugo-theme
-github.com/zwbetz-gh/cupper-hugo-theme
-github.com/zwbetz-gh/minimal-bootstrap-hugo-theme
-github.com/zwbetz-gh/papercss-hugo-theme
-github.com/zwbetz-gh/vanilla-bootstrap-hugo-theme
 github.com/zzossig/hugo-theme-zdoc
 github.com/zzossig/hugo-theme-zzo
 github.com/zzzmisa/hugo-theme-doors


### PR DESCRIPTION
Keeping archived theme, adds a lot of maintenance overhead.

With a theme that has not been updated in a few months, the author's intent is unclear.

With a theme that has been archived, the author's intent is very clear (i.e., I am not maintaining this anymore).