### PR TITLE
Remove the Doks theme from the list

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -141,7 +141,6 @@ github.com/GDGToulouse/devfest-theme-hugo
 github.com/geschke/hugo-tikva
 github.com/gesquive/slate
 github.com/gethinode/hinode
-github.com/gethyas/doks
 github.com/gevhaz/hugo-theme-notrack
 github.com/gizak/nofancy
 github.com/gkmngrgn/hugo-alageek-theme


### PR DESCRIPTION
Remove "Doks" - Theme isn't a Hugo theme (last compatible Hugo release has been squashed)