### PR TITLE
fix: remove cache for 2 themes

### DIFF
--- a/cmd/hugothemesitebuilder/build/cache/githubrepos.json
+++ b/cmd/hugothemesitebuilder/build/cache/githubrepos.json
@@ -1655,15 +1655,6 @@
     "html_url": "https://github.com/anparfenov/origin-hugo-theme",
     "stargazers_count": 44
   },
-  "github.com/frjo/hugo-theme-zen": {
-    "id": 84443022,
-    "created_at": "2017-03-09T13:05:40Z",
-    "updated_at": "2024-03-26T15:07:12Z",
-    "name": "hugo-theme-zen",
-    "description": "A fast and clean Hugo base theme with css-grid and Hugo pipes support.",
-    "html_url": "https://github.com/frjo/hugo-theme-zen",
-    "stargazers_count": 253
-  },
   "github.com/funkydan2/alpha-church": {
     "id": 131554115,
     "created_at": "2018-04-30T04:03:34Z",
@@ -2923,15 +2914,6 @@
     "description": "An easy on the eyes Hugo blog theme with dark mode.",
     "html_url": "https://github.com/nathancday/min_night",
     "stargazers_count": 20
-  },
-  "github.com/nicokaiser/hugo-theme-gallery": {
-    "id": 665672821,
-    "created_at": "2023-07-12T18:23:08Z",
-    "updated_at": "2024-03-26T13:41:06Z",
-    "name": "hugo-theme-gallery",
-    "description": "Gallery Theme for Hugo",
-    "html_url": "https://github.com/nicokaiser/hugo-theme-gallery",
-    "stargazers_count": 170
   },
   "github.com/nightswinger/hugo-theme-coyote": {
     "id": 535262094,

--- a/cmd/hugothemesitebuilder/build/config.json
+++ b/cmd/hugothemesitebuilder/build/config.json
@@ -812,12 +812,6 @@
         "ignoreConfig": true,
         "ignoreImports": true,
         "noMounts": true,
-        "path": "github.com/frjo/hugo-theme-zen"
-      },
-      {
-        "ignoreConfig": true,
-        "ignoreImports": true,
-        "noMounts": true,
         "path": "github.com/funkydan2/alpha-church"
       },
       {
@@ -1809,12 +1803,6 @@
         "ignoreImports": true,
         "noMounts": true,
         "path": "github.com/nathancday/min_night"
-      },
-      {
-        "ignoreConfig": true,
-        "ignoreImports": true,
-        "noMounts": true,
-        "path": "github.com/nicokaiser/hugo-theme-gallery"
       },
       {
         "ignoreConfig": true,

--- a/cmd/hugothemesitebuilder/build/go.mod
+++ b/cmd/hugothemesitebuilder/build/go.mod
@@ -187,7 +187,6 @@ require (
 	github.com/fncnt/vncnt-hugo v0.0.0-20231116105234-eda9f9246d9e // indirect
 	github.com/forestryio/hugo-theme-novela v0.0.0-20210222084032-5d015eef4c56 // indirect
 	github.com/fourtyone11/origin-hugo-theme v0.0.0-20200611125917-021c45772a9a // indirect
-	github.com/frjo/hugo-theme-zen v1.7.2 // indirect
 	github.com/funkydan2/alpha-church v0.0.0-20240318002523-975bb9dd385e // indirect
 	github.com/funkydan2/hugo-kiera v1.1.1 // indirect
 	github.com/g1eny0ung/hugo-theme-dream v1.6.0 // indirect
@@ -328,7 +327,6 @@ require (
 	github.com/naro143/hugo-coder-portfolio v0.0.0-20200903083500-255d92337c07 // indirect
 	github.com/natarajmb/charaka-hugo-theme v0.0.0-20201215113736-021bc743417b // indirect
 	github.com/nathancday/min_night v0.0.4 // indirect
-	github.com/nicokaiser/hugo-theme-gallery v0.0.0-20231122113845-52573f5990d6 // indirect
 	github.com/nightswinger/hugo-theme-coyote v1.0.2 // indirect
 	github.com/niklasbuschmann/contrast-hugo v0.0.0-20210313140659-9b3ec3d0243d // indirect
 	github.com/nirocfz/arabica v0.0.0-20220406035148-c63700f10450 // indirect

--- a/themes.txt
+++ b/themes.txt
@@ -132,7 +132,6 @@ github.com/floyd-li/hugo-theme-itheme
 github.com/fncnt/vncnt-hugo
 github.com/forestryio/hugo-theme-novela
 github.com/fourtyone11/origin-hugo-theme
-github.com/frjo/hugo-theme-zen
 github.com/funkydan2/alpha-church
 github.com/funkydan2/hugo-kiera
 github.com/g1eny0ung/hugo-theme-dream
@@ -299,7 +298,6 @@ github.com/nanxstats/hugo-tanka
 github.com/naro143/hugo-coder-portfolio
 github.com/natarajmb/charaka-hugo-theme
 github.com/nathancday/min_night
-github.com/nicokaiser/hugo-theme-gallery
 github.com/Nigh/tinyworks
 github.com/nightswinger/hugo-theme-coyote
 github.com/niklasbuschmann/contrast-hugo


### PR DESCRIPTION
I observed 2 themes having outdated information on themes.gohugo.io website. Meaning, the information displayed on `https://themes.gohugo.io/themes/abc/` is not what is present in README of theme `abc`.

This PR attempts to fix this issue by removing cache & go.mod ( `cmd/hugothemesitebuilder/build/go.mod`) entries corresponding to these themes.