### PR TITLE
chore: update version for hugo theme gallery

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -300,6 +300,7 @@ github.com/nanxstats/hugo-tanka
 github.com/naro143/hugo-coder-portfolio
 github.com/natarajmb/charaka-hugo-theme
 github.com/nathancday/min_night
+github.com/nicokaiser/hugo-theme-gallery
 github.com/Nigh/tinyworks
 github.com/nightswinger/hugo-theme-coyote
 github.com/niklasbuschmann/contrast-hugo

--- a/themes.txt
+++ b/themes.txt
@@ -300,7 +300,7 @@ github.com/nanxstats/hugo-tanka
 github.com/naro143/hugo-coder-portfolio
 github.com/natarajmb/charaka-hugo-theme
 github.com/nathancday/min_night
-github.com/nicokaiser/hugo-theme-gallery
+github.com/nicokaiser/hugo-theme-gallery/v4
 github.com/Nigh/tinyworks
 github.com/nightswinger/hugo-theme-coyote
 github.com/niklasbuschmann/contrast-hugo


### PR DESCRIPTION
Update theme metadata for github.com/nicokaiser/hugo-theme-gallery .