### PR TITLE
Add hermit-V2 theme

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -1,5 +1,6 @@
 github.com/10mohi6/hugo-theme-simple-blog
 github.com/17ms/yuan
+github.com/1bl4z3r/hermit-V2
 github.com/2-REC/hugo-myportfolio-theme
 github.com/4ever9/less
 github.com/4s3ti/hugo-theme-hello-4s3ti


### PR DESCRIPTION
hermit-V2 theme was removed from Hugo Themes due to missing screenshot. This is resolved and requesting to re-add the theme back to themes listing

After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

- [x] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [x] name
    - [x] license
    - [x] licenselink
    - [x] description
    - [x] homepage
    - [x] demosite (if one exists)
    - [x] tags
    - [x] features
    - [x] authors/author (depending on whether the theme has multiple or a single author)
    - [x] original (if the theme is a fork)
- [x] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [x] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [x] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)