### PR TITLE
Add Quint theme

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -434,6 +434,7 @@ github.com/urjaacharya/redgood
 github.com/vaga/hugo-theme-m10c
 github.com/vantagedesign/ace-documentation
 github.com/victoriadrake/hugo-theme-introduction
+github.com/victoriadrake/hugo-theme-quint
 github.com/victoriadrake/neofeed-theme/v2
 github.com/Vimux/Binario
 github.com/vimux/blank


### PR DESCRIPTION
Adds a new minimalist theme with a light airy feel, site search, built-in image banners, and automatic dark and light modes.

After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

- [x] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [x] name
    - [x] license
    - [x] licenselink
    - [x] description
    - [x] homepage
    - [x] demosite (if one exists)
    - [x] tags
    - [x] features
    - [x] authors/author (depending on whether the theme has multiple or a single author)
    - ~~original (if the theme is a fork)~~
- [x] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [x] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [x] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)
