### PR TITLE
Add theme linkbox

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -98,6 +98,7 @@ github.com/darshanbaral/sada
 github.com/dataCobra/hugo-vitae
 github.com/davidhampgonsalves/hugo-black-and-light-theme
 github.com/dchucks/agnes-hugo-theme
+github.com/deltronik/linkbox
 github.com/derme302/triple-hyde
 github.com/devcows/hugo-universal-theme
 github.com/dewittn/hugo-html5up-alpha


### PR DESCRIPTION
After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

- [ . ] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [ . ] name
    - [ . ] license
    - [ . ] licenselink
    - [ . ] description
    - [x] homepage
    - [ . ] demosite (if one exists)
    - [ . ] tags
    - [ . ] features
    - [ . ] authors/author (depending on whether the theme has multiple or a single author)
    - [ . ] original (if the theme is a fork)
- [ . ] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [ . ] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [.] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)
