### PR TITLE
Add hugo-porto theme

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -172,6 +172,7 @@ github.com/httpsecure/kembang
 github.com/hugcis/hugo-astatine-theme
 github.com/hugo-fixit/FixIt
 github.com/hugo-next/hugo-theme-next
+github.com/hugo-porto/theme
 github.com/hugo-sid/hugo-blog-awesome
 github.com/hugo-toha/toha/v4
 github.com/HugoBlox/hugo-blox-builder/modules/blox-tailwind


### PR DESCRIPTION
After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

- [x] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [x] name
    - [x] license
    - [x] licenselink
    - [x] description
    - [x] homepage
    - [x] demosite (if one exists)
    - [x] tags
    - [x] features
    - [x] authors/author (depending on whether the theme has multiple or a single author)
    - [x] original (if the theme is a fork)
- [x] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [x] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [x] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)
