### PR TITLE
Add theme linkbox

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -98,6 +98,7 @@ github.com/darshanbaral/sada
 github.com/dataCobra/hugo-vitae
 github.com/davidhampgonsalves/hugo-black-and-light-theme
 github.com/dchucks/agnes-hugo-theme
+github.com/deltronik/linkbox
 github.com/derme302/triple-hyde
 github.com/devcows/hugo-universal-theme
 github.com/dewittn/hugo-html5up-alpha


### PR DESCRIPTION
After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

- [ x] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [x ] name
    - [x] license
    - [x] licenselink
    - [x] description
    - [x] homepage
    - [x] demosite (if one exists)
    - [x] tags
    - [x] features
    - [x] authors/author (depending on whether the theme has multiple or a single author)
    - [x] original (if the theme is a fork)
- [x] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [x] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [x] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)
