### PR TITLE
Disable demo link and links in theme READMEs

### DIFF
--- a/cmd/hugothemesitebuilder/build/site/go.mod
+++ b/cmd/hugothemesitebuilder/build/site/go.mod
@@ -4,5 +4,5 @@ go 1.16
 
 require (
 	github.com/gohugoio/gohugoioTheme v0.0.0-20240508091825-b23e8e2d2419 // indirect
-	github.com/gohugoio/hugoThemesSite v0.0.0-20240508092046-c60406304339
+	github.com/gohugoio/hugoThemesSite v0.0.0-20240515150039-584ce012ee7f
 )

--- a/cmd/hugothemesitebuilder/build/site/go.sum
+++ b/cmd/hugothemesitebuilder/build/site/go.sum
@@ -13,3 +13,5 @@ github.com/gohugoio/hugoThemesSite v0.0.0-20240125095428-964006cadb41 h1:nKhHyYp
 github.com/gohugoio/hugoThemesSite v0.0.0-20240125095428-964006cadb41/go.mod h1:Um2gWoqNvIM9ss6TP1iSAzldlUzeMzZxNv6C94P6Snk=
 github.com/gohugoio/hugoThemesSite v0.0.0-20240508092046-c60406304339 h1:Rqhq6wbjTrPuimpcQDI65jaViwBV2n6LwVAETYOpB9w=
 github.com/gohugoio/hugoThemesSite v0.0.0-20240508092046-c60406304339/go.mod h1:/gs9qI8d+qXJdA/eZToqMq0FW8hIcmrVBPec9b1Gnis=
+github.com/gohugoio/hugoThemesSite v0.0.0-20240515150039-584ce012ee7f h1:5nFxW9z69T6iwwHulam50tG50lwpNwVWeECQ3Vh6OI8=
+github.com/gohugoio/hugoThemesSite v0.0.0-20240515150039-584ce012ee7f/go.mod h1:/gs9qI8d+qXJdA/eZToqMq0FW8hIcmrVBPec9b1Gnis=

--- a/cmd/hugothemesitebuilder/build/site/hugo.toml
+++ b/cmd/hugothemesitebuilder/build/site/hugo.toml
@@ -82,6 +82,7 @@ disableKinds    = ["taxonomy"]
   github_repo = "https://github.com/gohugoio/hugoThemesSiteBuilder"
   gitter      = "https://gitter.im/spf13/hugo"
   forum       = "https://discourse.gohugo.io/"
+  hideDemoLink = true
   #This array is meant for disabling the Homepage button of a theme.
   noHomePage = ["hugo-theme-novela"]
 

--- a/cmd/hugothemesitebuilder/build/site/layouts/_default/_markup/render-link.html
+++ b/cmd/hugothemesitebuilder/build/site/layouts/_default/_markup/render-link.html
@@ -1,0 +1,2 @@
+{{ .Text | default .Title | safeHTML }}
+{{- /* chomp trailing newline */ -}}


### PR DESCRIPTION
This relates to #423.

* People making money from Hugo themes is a great thing.
* I suspect a big motivation for Hugo theme authors that run a commercial theme site (or they sell their themes on a commercial site) is to get links to that site from `gohugo.io`, which has a pretty good Google ranking. This site isn't a free ad platform.
* This PR may be a bit drastic, but it should simplify some of the related discussions.
