### PR TITLE
Add theme ananthb/jughead

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -25,6 +25,7 @@ github.com/alloydwhitlock/huey
 github.com/AmazingRise/hugo-theme-diary
 github.com/ameio/hugo-arogya-theme
 github.com/AminZibayi/Corporio
+github.com/ananthb/jughead
 github.com/AngeloStavrow/indigo
 github.com/antedoro/arberia
 github.com/antonpolishko/hugo-stellar-theme


### PR DESCRIPTION
ananthb/jughead is a lightweight blog theme for Hugo.

After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

- [X] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [X] name
    - [X] license
    - [X] licenselink
    - [X] description
    - [X] homepage
    - [X] demosite (if one exists)
    - [X] tags
    - [X] features
    - [X] authors/author (depending on whether the theme has multiple or a single author)
    - [X] original (if the theme is a fork)
- [X] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [X] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [X] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)
