### PR TITLE
Add theme archie-solarized

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -160,6 +160,7 @@ github.com/halogenica/beautifulhugo
 github.com/hauke96/hugo-theme-hamburg
 github.com/hbstack/theme
 github.com/hbstack/theme-start
+github.com/hcartiaux/hugo-theme-archie-solarized
 github.com/hdcdstr8fwd/foundation-theme
 github.com/HEIGE-PCloud/DoIt
 github.com/heksagonnet/piko


### PR DESCRIPTION
This is a fork from [Ahtul Archie Theme](https://github.com/athul/archie), it supports a dark and light mode strictly based on the [Solarized color scheme](https://ethanschoonover.com/solarized/) and guidelines (for background and content tones). It also adds support for tables of contents.

This theme is only based on the Solarized color palette, no other color is used. I think it makes it ideal for any development oriented blog which includes code or terminal extracts.

I know it's a fork, but I've not seen a single Solarized-based theme listed on themes.hugo.io, so I thought this one would be a valuable addition. I let you decide if it makes sense to accept this PR.

Homework done:

- [x] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [x] name
    - [x] license
    - [x] licenselink
    - [x] description
    - [x] homepage
    - [x] demosite (if one exists)
    - [x] tags
    - [x] features
    - [x] authors/author (depending on whether the theme has multiple or a single author)
    - [x] original (if the theme is a fork)
- [x] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [x] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [x] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)
