### PR TITLE
Fix broken revision ref for github.com/jgazeau/shadocs to unlock github actions

### DIFF
--- a/cmd/hugothemesitebuilder/build/go.mod
+++ b/cmd/hugothemesitebuilder/build/go.mod
@@ -255,7 +255,7 @@ require (
 	github.com/jeblister/bulma v0.0.0-20220331084658-8d25840df6ac // indirect
 	github.com/jeremybise/twentynineteen-hugo v0.0.0-20191008161335-7c0a63e24114 // indirect
 	github.com/jesselau76/hugo-w3-simple v0.0.0-20220609000310-88c02cc42a3a // indirect
-	github.com/jgazeau/shadocs v0.0.0-20240812174418-3d42b7a6bebf // indirect
+	github.com/jgazeau/shadocs v0.0.0-20240824100853-7fc02bb65a1d // indirect
 	github.com/jimfrenette/hugo-starter v0.0.0-20240318133913-6e17fb5b9b1c // indirect
 	github.com/jmablog/hugo-clinic-notes v0.0.0-20210111134623-7f5a64696c35 // indirect
 	github.com/jmau111/hugo-theme-ava v0.0.0-20230116180948-0b624aa47065 // indirect


### PR DESCRIPTION
There is an issue with downloading `github.com/jgazeau/shadocs` due to the missing revision that blocks github actions.

This PR manually updates refs for this package to the latest commit in the repository.

Link to the error: https://github.com/gohugoio/hugoThemesSiteBuilder/actions/runs/10542610626/job/29209583370#step:4:163
