### PR TITLE
fix: Hide showcase section

### DIFF
--- a/cmd/hugothemesitebuilder/build/site/hugo.toml
+++ b/cmd/hugothemesitebuilder/build/site/hugo.toml
@@ -106,11 +106,11 @@ disableKinds    = ["taxonomy"]
   identifier = "themes"
   url        = "https://themes.gohugo.io/"
 
-[[menu.global]]
-  name       = "Showcase"
-  weight     = 20
-  identifier = "showcase"
-  url        = "https://gohugo.io/showcase/"
+#[[menu.global]]
+#  name       = "Showcase"
+#  weight     = 20
+#  identifier = "showcase"
+#  url        = "https://gohugo.io/showcase/"
 
 [[menu.global]]
   name       = "Community"


### PR DESCRIPTION
## Description 

Currently the showcase menu is hidden on the hugoDocs repository, see [commit](https://github.com/gohugoio/hugoDocs/commit/fb140b15395199796e8c445412f1afb1c1d0a0c8).

When a visitor look at the theme website, the showcase menu entry is displayed and leads to a 404 page. 

This PR hides the showcase menu entry on the theme site. I only commented the code as it was done on the main documentation site.

- [x] CLA signed 
- [x] tested locally 