### PR TITLE
Fix: Resolve 404 error for 'Dark mode' tagged themes link

### DIFF
--- a/pkg/buildcmd/build.go
+++ b/pkg/buildcmd/build.go
@@ -490,9 +490,9 @@ var goodTags = map[string]interface{}{
 	"company":      true,
 	"business":     "company",
 	"dark":         true,
-	"dark mode":    true,
+	"dark-mode":    true,
 	"hero":         true,
-	"light mode":   true,
+	"light-mode":   true,
 	"ecommerce":    true,
 	"gallery":      true,
 	"green":        true,
@@ -518,6 +518,7 @@ var goodTags = map[string]interface{}{
 
 func normalizeTag(s string) string {
 	s = strings.ToLower(s)
+	s = strings.ReplaceAll(s, " ", "-")
 
 	if v, found := goodTags[s]; found {
 		switch vv := v.(type) {


### PR DESCRIPTION
**Overview**  
Fixes a 404 error when clicking the 'dark mode' hyperlink.

**Changes**  
- Replaced spaces with hyphens in the 'dark mode' URL.  
- Adjusted the 'dark mode' tag configuration for proper recognition.

Resolves #466.
