### PR TITLE
Add theme hugo-saasify-theme after fixing image dimensions

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -67,6 +67,7 @@ github.com/cathelijne/hugo-theme-huguette
 github.com/cboettig/hugo-now-ui
 github.com/cdeck3r/OneDly-Theme
 github.com/cfrome77/hugo-theme-sky
+github.com/chaoming/hugo-saasify-theme
 github.com/chaitanya4vedi/navada
 github.com/chipsenkbeil/grid-side
 github.com/chipzoller/hugo-clarity


### PR DESCRIPTION
hugo new theme Saasify

After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

- [x] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [x] name
    - [x] license
    - [x] licenselink
    - [x] description
    - [x] homepage
    - [x] demosite (if one exists)
    - [x] tags
    - [x] features
    - [x] authors/author (depending on whether the theme has multiple or a single author)
    - [x] original (NA, not a fork)
- [x] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [x] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [x] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)
