### PR TITLE
Added theme professionalaf/hugo-news

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -352,6 +352,7 @@ github.com/PippoRJ/hugo-refresh
 github.com/pjbakker/flexible-seo-hugo
 github.com/plopcas/papaya
 github.com/pravin/hugo-theme-prav
+github.com/professionalaf/hugo-news
 github.com/progrhyme/hugo-theme-bootie-docs
 github.com/puresyntax71/hugo-theme-chunky-poster
 github.com/qqhann/hugo-primer


### PR DESCRIPTION
After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

- [x] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [x] name
    - [x] license
    - [x] licenselink
    - [x] description
    - [x] homepage
    - [x] demosite (if one exists)
    - [x] tags
    - [x] features
    - [x] authors/author (depending on whether the theme has multiple or a single author)
    - [x] original (if the theme is a fork)
- [x] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [x] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [x] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)
