### PR TITLE
Simplify module setup

### DIFF
--- a/cmd/hugothemesitebuilder/build/site/go.mod
+++ b/cmd/hugothemesitebuilder/build/site/go.mod
@@ -4,7 +4,6 @@ go 1.23
 
 toolchain go1.24.2
 
-require github.com/gohugoio/hugoThemesSite v0.0.0-20250413153523-218508d22d87
 
 require (
 	github.com/gohugoio/hugoDocs v0.146.1 // indirect

--- a/cmd/hugothemesitebuilder/build/site/go.sum
+++ b/cmd/hugothemesitebuilder/build/site/go.sum
@@ -1,4 +1,2 @@
 github.com/gohugoio/hugoDocs v0.146.1 h1:f1q3NrNBLwI1docyPcvR6lIgpXlPg6jXQ/pct2YqBXc=
 github.com/gohugoio/hugoDocs v0.146.1/go.mod h1:5tw9S3zNniW5wuNPkCHrFhfpIoqXRhBDq7hM9ZbcO7I=
-github.com/gohugoio/hugoThemesSite v0.0.0-20250413153523-218508d22d87 h1:e+uvV8oLcYR6a+AAkF5KlD73P71cbZcoXLQ8jgfXcGs=
-github.com/gohugoio/hugoThemesSite v0.0.0-20250413153523-218508d22d87/go.mod h1:k8gbZMqjx3U0/aU6MvkO8U3ilp29vZhQImuw9uGKF4I=

--- a/cmd/hugothemesitebuilder/build/site/hugo.toml
+++ b/cmd/hugothemesitebuilder/build/site/hugo.toml
@@ -16,13 +16,36 @@ googleAnalytics = "G-MBZGKNMDWC"
 
 [module]
   [module.hugoVersion]
-    min = "0.100.0"
+    min = "0.145.0"
+  [[module.mounts]]
+    source = "layouts"
+    target = "layouts"
+  [[module.mounts]]
+    source = "content"
+    target = "content"
   [[module.mounts]]
     disableWatch = true
     source       = "hugo_stats.json"
     target       = "assets/notwatching/hugo_stats.json"
   [[module.imports]]
-    path = "github.com/gohugoio/hugoThemesSite"
+    path = "github.com/gohugoio/hugoDocs"
+    # We share the theme with the docs site, but we need to be explicit about
+    # the mounts to avoid pulling in the content.
+    [[module.imports.mounts]]
+      source = "layouts"
+      target = "layouts"
+    [[module.imports.mounts]]
+      source = "assets"
+      target = "assets"
+    [[module.imports.mounts]]
+      source = "static"
+      target = "static"
+    [[module.imports.mounts]]
+      source = "data"
+      target = "data"
+    [[module.imports.mounts]]
+      source = "i18n"
+      target = "i18n"
 
 [markup.goldmark.renderer]
   # We pull in README.md files from the theme repos, and they can have HTML,

--- a/cmd/hugothemesitebuilder/build/site/hugo.work
+++ b/cmd/hugothemesitebuilder/build/site/hugo.work
@@ -1,4 +1,3 @@
 go 1.23
 
-use ../../../../../hugoThemesSite
 use ../../../../../hugoDocs

--- a/cmd/hugothemesitebuilder/build/site/layouts/_partials/breadcrumbs.html
+++ b/cmd/hugothemesitebuilder/build/site/layouts/_partials/breadcrumbs.html
@@ -1,0 +1,33 @@
+<nav aria-label="breadcrumb" class="flex breadcrumbs">
+  <ol class="inline-flex items-center flex-wrap tracking-tight">
+    {{ $currentSection := .CurrentSection }}
+    {{ $ancestors := .Ancestors.Reverse }}
+    {{ range $i, $p := $ancestors }}
+      {{ $isCurrentSection := eq $p $currentSection }}
+      <li class="flex items-center">
+        {{ $isLast := eq $i (sub (len $ancestors) 1) }}
+        <a
+          href="{{ $p.RelPermalink }}"
+          class="truncate text-blue-600 hover:text-blue-500 dark:text-blue-500 dark:hover:text-blue-400 {{ if $isCurrentSection }}
+            current-section
+          {{ end }}"
+          >{{ $p.LinkTitle }}</a
+        >
+        {{ template "breadcrumbs-arrow" . }}
+      </li>
+    {{ end }}
+    {{ $isCurrentSection := eq $ $currentSection }}
+    <li
+      class="truncate text-gray-700 dark:text-gray-300 {{ if $isCurrentSection }}
+        current-section
+      {{ end }}">
+      {{ $.LinkTitle }}
+    </li>
+  </ol>
+</nav>
+
+{{ define "breadcrumbs-arrow" }}
+  <svg class="fill-gray-500 dark:fill-gray-100 w-3 h-3 mx-2">
+    <use href="#icon--chevron-right"></use>
+  </svg>
+{{ end }}

--- a/cmd/hugothemesitebuilder/build/site/layouts/_partials/listtags.html
+++ b/cmd/hugothemesitebuilder/build/site/layouts/_partials/listtags.html
@@ -1,0 +1,19 @@
+{{ $tags := site.Taxonomies.tags.ByCount }}
+{{ $tags = where $tags "Count" ">=" 3 }}
+
+
+<nav role="navigation" class="pt-2 pl-2 px-4">
+  <h3 class="text-base font-semibold">Tags</h3>
+  <ul class="mt-3 space-y-1">
+    {{ range $tags }}
+      <li class="text-base">
+        <a
+          href="{{ .Page.RelPermalink }}"
+          class="text-blue-600 hover:text-blue-500
+dark:hover:text-blue-200 dark:text-blue-200">
+          {{ .Name }} ({{ .Count }})
+        </a>
+      </li>
+    {{ end }}
+  </ul>
+</nav>

--- a/cmd/hugothemesitebuilder/build/site/layouts/_partials/themes.html
+++ b/cmd/hugothemesitebuilder/build/site/layouts/_partials/themes.html
@@ -1,0 +1,34 @@
+<ul
+  role="list"
+  class="grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-3 sm:gap-x-6 lg:grid-cols-4 xl:gap-x-8">
+  {{ range $i, $e := . }}
+    {{ $img := (.Resources.ByType "image").GetMatch "*tn*" }}
+    {{ if not $img }}
+      {{ continue }}
+    {{ end }}
+
+
+    <li class="relative">
+      <div
+        class="group overflow-hidden rounded-lg bg-gray-100 focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 focus-within:ring-offset-gray-100">
+        {{ partial "helpers/picture.html" (dict
+          "image" $img
+          "alt" "Hugo Theme"
+          "width" 512
+          "loading" (cond (ge $i 20) "lazy" "eager")
+          "class" "pointer-events-none aspect-10/7 object-cover group-hover:opacity-75")
+        }}
+        <a
+          href="{{ .RelPermalink }}"
+          type="button"
+          class="cursor-pointer absolute inset-0 focus:outline-hidden">
+          <span class="sr-only">View details for {{ .LinkTitle }}</span>
+        </a>
+      </div>
+      <p
+        class="pointer-events-none mt-2 block truncate text-sm font-medium text-gray-900 dark:text-gray-100">
+        {{ .LinkTitle }}
+      </p>
+    </li>
+  {{ end }}
+</ul>

--- a/cmd/hugothemesitebuilder/build/site/layouts/home.html
+++ b/cmd/hugothemesitebuilder/build/site/layouts/home.html
@@ -1,0 +1,11 @@
+{{ define "main" }}
+  {{ partial "themes.html" site.RegularPages }}
+{{ end }}
+
+{{ define "rightsidebar_content" }}
+  {{ partial "listtags.html" . }}
+{{ end }}
+
+{{ define "leftsidebar" }}
+  {{ printf "%c" '\u00A0' }}
+{{ end }}

--- a/cmd/hugothemesitebuilder/build/site/layouts/list.html
+++ b/cmd/hugothemesitebuilder/build/site/layouts/list.html
@@ -1,0 +1,17 @@
+{{ define "main" }}
+  {{ partial "themes.html" .RegularPages }}
+{{ end }}
+
+{{ define "subheader" }}
+  <div class="mt-8 mx-auto max-w-7xl">
+    {{ partial "breadcrumbs.html" . }}
+  </div>
+{{ end }}
+
+{{ define "rightsidebar" }}
+  {{ printf "%c" '\u00A0' }}
+{{ end }}
+
+{{ define "leftsidebar" }}
+  {{ printf "%c" '\u00A0' }}
+{{ end }}

--- a/cmd/hugothemesitebuilder/build/site/layouts/single.html
+++ b/cmd/hugothemesitebuilder/build/site/layouts/single.html
@@ -1,0 +1,141 @@
+{{ define "hero" }}
+  <div class="relative isolate overflow-hidden">
+    <div
+      class="mx-auto max-w-7xl px-6 pt-10 lg:py-20 pb-24 sm:pb-32 lg:flex lg:px-8">
+      <div class="mx-auto max-w-2xl lg:mx-0 lg:shrink-0 lg:pt-8">
+        <h1
+          class="mt-10 text-5xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-7xl dark:text-gray-100">
+          {{ .Title }}
+        </h1>
+        <p
+          class="mt-8 text-lg font-medium text-pretty text-gray-500 sm:text-xl/8">
+          {{ with .Params.meta.description }}{{ . }}{{ end }}
+        </p>
+
+        {{ template "theme-details" . }}
+        <div class="mt-10 flex items-center gap-x-6">
+          {{ if not site.Params.hideHTMLLink }}
+            {{ with .Params.htmlURL }}
+              <a
+                href="{{ . }}"
+                class="rounded-md bg-blue-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+                >Download</a
+              >
+            {{ end }}
+          {{ end }}
+          {{ if not site.Params.hideDemoLink }}
+            {{ with .Params.meta.demosite }}
+              <a
+                href="{{ . }}"
+                class="rounded-md bg-green-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-green-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+                >Demo</a
+              >
+            {{ end }}
+          {{ end }}
+        </div>
+      </div>
+      <div
+        class="mx-auto mt-16 flex max-w-2xl sm:mt-24 lg:mt-0 lg:mr-0 lg:ml-10 lg:max-w-none lg:flex-none xl:ml-32">
+        {{ $img := (.Resources.ByType "image").GetMatch "*screen*" }}
+        {{ if $img }}
+          {{ partial "helpers/picture.html" (dict
+            "image" $img
+            "alt" "Theme Screenshot"
+            "width" 1280
+            "class" "w-[76rem] rounded-md shadow-2xl ring-1 ring-gray-900/10")
+          }}
+        {{ end }}
+
+      </div>
+    </div>
+  </div>
+{{ end }}
+
+{{ define "main" }}
+  <div class="flex flex-col w-full p-0 m-0 content">
+    {{ .Content }}
+  </div>
+{{ end }}
+
+{{ define "subheader" }}
+  <div class="mt-8 mx-auto max-w-7xl">
+    {{ partial "breadcrumbs.html" . }}
+  </div>
+{{ end }}
+
+{{ define "rightsidebar" }}
+  {{ printf "%c" '\u00A0' }}
+{{ end }}
+
+{{ define "leftsidebar" }}
+  {{ printf "%c" '\u00A0' }}
+{{ end }}
+
+{{ define "theme-details" }}
+  <div>
+    <div class="mt-6 border-t border-gray-100">
+      <dl class="divide-y divide-gray-100">
+        {{ with .Params.meta.license }}
+          {{ template "descriptionlist-item" (dict "label" "License" "value" . ) }}
+        {{ end }}
+        {{ with .Params.githubInfo }}
+          {{ template "descriptionlist-item" (dict "label" "GitHub Stars" "value" .Stars ) }}
+        {{ end }}
+        {{ with .Params.hugoVersion.min }}
+          {{ template "descriptionlist-item" (dict "label" "Minimum Hugo Version" "value" . ) }}
+        {{ end }}
+        {{ template "descriptionlist-item" (dict "label" "Last Updated" "value" ( .Lastmod.Format "2006-01-02") ) }}
+        {{ with .Params.meta.author }}
+          {{ if reflect.IsMap . }}
+            {{ template "descriptionlist-item" (dict "label" "Author" "value" .name "link" .homepage ) }}
+          {{ end }}
+        {{ end }}
+        {{ with .Params.meta.authors }}
+          {{ range . }}
+            {{ template "descriptionlist-item" (dict "label" "Author" "value" .name "link" .homepage ) }}
+          {{ end }}
+        {{ end }}
+
+        {{ with (.GetTerms "tags") }}
+          <div class="px-4 py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+            <dt class="text-sm/6 font-medium text-gray-900 dark:text-gray-100">
+              Tags
+            </dt>
+            <dd class="mt-1 text-sm/6 text-gray-700 sm:col-span-2 sm:mt-0">
+              {{ range . }}
+                <a
+                  href="{{ .Permalink }}"
+                  class="text-blue-600 hover:text-blue-600
+        dark:hover:text-blue-200 dark:text-blue-200">
+                  {{ .LinkTitle | title }}
+                </a>
+              {{ end }}
+            </dd>
+          </div>
+        {{ end }}
+
+      </dl>
+    </div>
+  </div>
+{{ end }}
+
+{{ define "descriptionlist-item" }}
+  <div class="px-4 py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+    <dt class="text-sm/6 font-medium text-gray-900 dark:text-gray-100">
+      {{ .label }}
+    </dt>
+    <dd
+      class="mt-1 text-sm/6 text-gray-700 dark:text-gray-200 sm:col-span-2 sm:mt-0">
+      {{ if .link }}
+        <a
+          href="{{ .link }}"
+          class="text-blue-600 hover:text-blue-600
+dark:hover:text-blue-200 dark:text-blue-200">
+          {{ .value }}
+        </a>
+      {{ else }}
+        {{ .value }}
+      {{ end }}
+    </dd>
+  </div>
+{{ end }}

--- a/cmd/hugothemesitebuilder/build/site/layouts/taxonomy.html
+++ b/cmd/hugothemesitebuilder/build/site/layouts/taxonomy.html
@@ -1,0 +1,36 @@
+{{ define "main" }}
+
+  <article class="">
+    <div class="grid grid-cols-2 xl:grid-cols-3 gap-4 min-h-40">
+      {{ range .Pages }}
+        <a
+          class="flex col-span-1 a--block cursor-pointer flex-col group border p-3 sm:p-4 hover:shadow-md dark:shadow-slate-800 border-gray-300 dark:border-gray-800 m-0"
+          href="{{ .RelPermalink }}">
+          <h3
+            class="text-lg/6 md:text-2xl tracking-tight p-0 -mt-1 sm:mt-0 mb-1 sm:mb-2 text-primary group-hover:text-primary/70 overflow-hidden">
+            {{ .LinkTitle }}
+          </h3>
+
+          <p
+            class="text-black dark:text-gray-100 leading-6 text-sm md:text-base three-lines-ellipsis">
+            {{ (or .Params.description .Summary) | plainify | safeHTML }}
+          </p>
+        </a>
+      {{ end }}
+    </div>
+  </article>
+{{ end }}
+
+{{ define "subheader" }}
+  <div class="flex  flex-auto w-full xl:w-6xl mx-auto my-8">
+    {{ partial "breadcrumbs.html" . }}
+  </div>
+{{ end }}
+
+{{ define "rightsidebar" }}
+  {{ printf "%c" '\u00A0' }}
+{{ end }}
+
+{{ define "leftsidebar" }}
+  {{ printf "%c" '\u00A0' }}
+{{ end }}

--- a/cmd/hugothemesitebuilder/build/site/layouts/thumbnail.html
+++ b/cmd/hugothemesitebuilder/build/site/layouts/thumbnail.html
@@ -1,0 +1,16 @@
+{{ $img := (.Resources.ByType "image").GetMatch "*tn*" }}
+{{ with $img }}
+  {{ $big := .Fill "768x512 top" }}
+  {{ $small := .Fill "384x256 top" }}
+  <a href="{{ $.Permalink }}" class="link db shadow-hover gray mb4 w-100 w-30-ns">
+    <img class="lazyload fit db ba b--moon-gray" alt="{{ $.Description }}" src="data:image/svg+xml;charset=utf8,%3Csvg%20width='1800'%20height='1200'%20viewBox='0%200%201800%201200'%20xmlns='http://www.w3.org/2000/svg'%3E%3Ctitle%3EThumbnail%3C/title%3E%3Cg%20fill='none'%20fill-rule='evenodd'%3E%3Cpath%20fill='%23FFF'%20d='M0%200h1800v1200H0z'/%3E%3Ctext%20opacity='0.5'%20font-family='Muli,%20avenir,helvetica%20neue,helvetica,ubuntu,roboto,noto,segoe%20ui,arial,sans-serif'%20font-size='288'%20fill='#0594CB'%3E%3Ctspan%20x='468'%20y='674'%3EHUGO%3C/tspan%3E%3C/text%3E%3C/g%3E%3C/svg%3E" 
+    data-sizes="auto"
+    data-srcset="{{ $small.RelPermalink }} 1x, {{ $big.RelPermalink }} 2x" data-bg="{{ $small.RelPermalink }}"  />
+    <noscript>
+      <img class="fit db ba b--moon-gray" alt="{{ $.Description }}" srcset="{{ $small.RelPermalink }} 1x, { $big.RelPermalink }} 2x" />
+    </noscript>
+    <span class="f6 dark-gray w-100 db">
+      {{ $.Title }}
+    </span>
+  </a>
+{{ end }}

--- a/pkg/buildcmd/build.go
+++ b/pkg/buildcmd/build.go
@@ -66,6 +66,7 @@ func New(rootConfig *rootcmd.Config) *ffcli.Command {
 func (c *Config) Exec(ctx context.Context, args []string) error {
 	const configAll = "config.json"
 	contentDir := c.rootConfig.Client.JoinOutPath("site", "content")
+	contentThemesDir := filepath.Join(contentDir, "themes")
 	staticDir := c.rootConfig.Client.JoinOutPath("site", "static")
 	configFile := c.rootConfig.Client.JoinOutPath(configAll)
 	client.CheckErr(os.Remove(configFile))
@@ -101,9 +102,9 @@ func (c *Config) Exec(ctx context.Context, args []string) error {
 	}
 
 	if !c.noClean {
-		client.CheckErr(os.RemoveAll(contentDir))
+		client.CheckErr(os.RemoveAll(contentThemesDir))
 	}
-	client.CheckErr(os.MkdirAll(contentDir, 0o777))
+	client.CheckErr(os.MkdirAll(contentThemesDir, 0o777))
 
 	if err := bc.writeThemesContent(); err != nil {
 		return err


### PR DESCRIPTION
Include hugoDocs directly.

After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

- [ ] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [ ] name
    - [ ] license
    - [ ] licenselink
    - [ ] description
    - [ ] homepage
    - [ ] demosite (if one exists)
    - [ ] tags
    - [ ] features
    - [ ] authors/author (depending on whether the theme has multiple or a single author)
    - [ ] original (if the theme is a fork)
- [ ] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [ ] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [ ] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)
