### PR TITLE
Add LucentLink-Hugo theme to themes.txt

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -13,6 +13,7 @@ github.com/AngeloStavrow/indigo
 github.com/Axorax/axile-hugo
 github.com/Binary-Eater/hugo-theme-ghci
 github.com/CaiJimmy/hugo-theme-stack/v3
+github.com/cx48/LucentLink-Hugo
 github.com/CyrusYip/hugo-theme-yue
 github.com/ElecBrandy/freshpink
 github.com/EmielH/hallo-hugo


### PR DESCRIPTION
After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

- [x] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [x] name
    - [x] license
    - [x] licenselink
    - [x] description
    - [x] homepage
    - [x] demosite (if one exists)
    - [x] tags
    - [x] features
    - [x] authors/author (depending on whether the theme has multiple or a single author)
    - [x] original (if the theme is a fork)
- [x] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [x] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [x] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)
