### PR TITLE
Add theme sine-die

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -436,6 +436,7 @@ github.com/shaform/hugo-theme-den
 github.com/shenoydotme/hugo-goa
 github.com/siegerts/hugo-theme-basic
 github.com/sieis/re-cover
+github.com/sinetris/sine-die
 github.com/slashformotion/hugo-tufte
 github.com/softwareyoga/ronu-hugo-theme
 github.com/spaghettiwews/hugonews


### PR DESCRIPTION
Followed [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme):

- [x] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [x] name
    - [x] license
    - [x] licenselink
    - [x] description
    - [x] homepage
    - [x] demosite (if one exists)
    - [x] tags
    - [x] features
    - [x] authors/author (depending on whether the theme has multiple or a single author)
    - [x] ~~original (if the theme is a fork)~~
- [x] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [x] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [x] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)

Related:

- This PR closes sinetris/sine-die#25
