### PR TITLE
add ntk148v/shibui theme

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -372,6 +372,7 @@ github.com/nixentric/Lowkey-Hugo-Theme
 github.com/nodejh/hugo-theme-cactus-plus
 github.com/ntk148v/hugo-cuisine-book
 github.com/ntk148v/hugo-toigian
+github.com/ntk148v/shibui
 github.com/nunocoracao/blowfish/v2
 github.com/nurlansu/hugo-sustain
 github.com/nusserstudios/tailbliss


### PR DESCRIPTION
After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

- [x] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [x] name
    - [x] license
    - [x] licenselink
    - [x] description
    - [x] homepage
    - [x] demosite (if one exists)
    - [x] tags
    - [x] features
    - [x] authors/author (depending on whether the theme has multiple or a single author)
    - [ ] original (if the theme is a fork)
- [x] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [x] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [x] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)
