### PR TITLE
Add theme vintage-web

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -489,6 +489,7 @@ github.com/undus5/hugo-pure
 github.com/urjaacharya/redgood
 github.com/vaga/hugo-theme-m10c
 github.com/vantagedesign/ace-documentation
+github.com/vibecodemama/vintage-web
 github.com/victoriadrake/hugo-theme-introduction
 github.com/victoriadrake/hugo-theme-quint
 github.com/victoriadrake/neofeed-theme/v2


### PR DESCRIPTION
Because who doesn't love the occasional sojourn to 1999?

After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

- [x] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [x] name
    - [x] license
    - [x] licenselink
    - [x] description
    - [x] homepage
    -  demosite (if one exists)
    - [x] tags
    - [x] features
    - [x] authors/author (depending on whether the theme has multiple or a single author)
    -  original (if the theme is a fork)
- [x] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [x] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [x] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)
