### PR TITLE
Add theme Hugo Simple Column

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -305,6 +305,7 @@ github.com/matsuyoshi30/harbor
 github.com/mattbutton/silhouette-hugo
 github.com/mattstratton/castanet
 github.com/mavidser/hugo-rocinante
+github.com/MaxwellBuchholz/hugo-simple-column
 github.com/mazgi/hugo-theme-techlog-simple
 github.com/mbrt-yeah/uwe-uwe-hugo
 github.com/mcrwfrd/hugo-frances-theme


### PR DESCRIPTION
I have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), and made sure that:

- [x] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [x] name
    - [x] license
    - [x] licenselink
    - [x] description
    - [x] homepage
    - [x] demosite (if one exists)
    - [x] tags
    - [x] features
    - [x] authors/author (depending on whether the theme has multiple or a single author)
    - [ ] original (if the theme is a fork)
- [x] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [x] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [x] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)
