### PR TITLE
add khata theme

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -102,6 +102,7 @@ github.com/danielkvist/hugo-piercer-theme
 github.com/danielkvist/hugo-terrassa-theme
 github.com/dannymcc/DMCC-Hugo-theme
 github.com/darshanbaral/aafu
+github.com/darshanbaral/khata
 github.com/darshanbaral/kitab
 github.com/darshanbaral/sada
 github.com/dataCobra/hugo-vitae


### PR DESCRIPTION
After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

- [x] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [x] name
    - [x] license
    - [x] licenselink
    - [x] description
    - [x] homepage
    - [x] demosite (if one exists)
    - [x] tags
    - [x] features
    - [x] authors/author (depending on whether the theme has multiple or a single author)
    - [ ] original (if the theme is a fork)
- [x] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [x] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [x] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)
