### PR TITLE
ci:  Do not fail when there is nothing to commit

### DIFF
--- a/.github/workflows/update-themes.yml
+++ b/.github/workflows/update-themes.yml
@@ -38,5 +38,5 @@ jobs:
           git config --global user.email "bep@users.noreply.github.com"
           git config --global user.name "bep"
           git add .
-          git commit -am "[Bot] Update themes"
+          git diff-index --quiet HEAD || git commit -am "[Bot] Update themes"
           git push --force-with-lease


### PR DESCRIPTION
When there is nothing to commit ci will fail with:

nothing to commit, working tree clean
Error: Process completed with exit code 1.

This was reported as #287.
Catch this by checking via `git diff-index` if there is anything to commit first.


----
None of the below should apply.
After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

- [ ] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [ ] name
    - [ ] license
    - [ ] licenselink
    - [ ] description
    - [ ] homepage
    - [ ] demosite (if one exists)
    - [ ] tags
    - [ ] features
    - [ ] authors/author (depending on whether the theme has multiple or a single author)
    - [ ] original (if the theme is a fork)
- [ ] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [ ] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [ ] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)
