### PR TITLE
Adding a gallery theme `hugo-foto-theme` aka `Foto`

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -357,6 +357,7 @@ github.com/ntk148v/shibui
 github.com/nunocoracao/blowfish/v2
 github.com/nurlansu/hugo-sustain
 github.com/nusserstudios/tailbliss
+github.com/nux-li/hugo-foto-theme
 github.com/okkur/syna
 github.com/ololiuhqui/magnolia-free-hugo-theme
 github.com/olOwOlo/hugo-theme-even


### PR DESCRIPTION
Foto uses a separate application Hippo (https://github.com/nux-li/hippo) for extracting metadata from JPEGs, resize the images and adding watermarks. It also creates front matter files.

By placing JPEGs in different album folders withing the content folder and running hippo as described in the README, a gallery with thumbnails and larger images are created. Below each large image you will find metadata such as title, description, keywords and different exposure details, all extracted by hippo. Some of the extracted metadata are even used as taxonomy terms.

After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

- [x] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [x] name
    - [x] license
    - [x] licenselink
    - [x] description
    - [x] homepage
    - [x] demosite (if one exists)
    - [x] tags
    - [x] features
    - [x] authors/author (depending on whether the theme has multiple or a single author)
    - [ ] original (if the theme is a fork)
- [x] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [x] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [x] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)
