### PR TITLE
Reinstate hugo-book theme

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -19,6 +19,7 @@ github.com/airinghost/hugo-theme-icarus-lite
 github.com/akatiggerx04/graysx-hugo
 github.com/akopdev/hugo-theme-chicago7
 github.com/alanorth/hugo-theme-bootstrap4-blog
+github.com/alex-shpak/hugo-book
 github.com/alexandrevicenzi/soho
 github.com/AlexFinn/simple-a
 github.com/allnightgrocery/hugo-theme-blueberry-detox


### PR DESCRIPTION
References:
https://github.com/alex-shpak/hugo-book/issues/774
https://github.com/gohugoio/hugoThemesSiteBuilder/commit/f78286e801d8657342eb645405299f4657bdf9c1

After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

- [x] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [x] name
    - [x] license
    - [x] licenselink
    - [x] description
    - [x] homepage
    - [x] demosite (if one exists)
    - [x] tags
    - [x] features
    - [x] authors/author (depending on whether the theme has multiple or a single author)
    - [x] original (if the theme is a fork)
- [x] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [x] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [x] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)
