### PR TITLE
Add Hugo Mana theme back to the list of available themes

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -294,6 +294,7 @@ github.com/leonstafford/accessible-minimalism-hugo-theme
 github.com/letItCurl/minimal_marketing
 github.com/lingxz/er
 github.com/liuzc/LeaveIt
+github.com/Livour/hugo-mana-theme
 github.com/lordmathis/hugo-theme-nightfall
 github.com/lordmathis/hugo-theme-nix
 github.com/loveminimal/hugo-theme-virgo


### PR DESCRIPTION
Theme Name: Mana
Theme Repository: https://github.com/Livour/hugo-mana-theme
Demo: https://managuide.blog/
License: MIT

This is a retry to add the theme, see #645 