### PR TITLE
Add hugo-fraktur-theme

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -361,10 +361,10 @@ github.com/nirocfz/arabica
 github.com/nixentric/Lowkey-Hugo-Theme
 github.com/nodejh/hugo-theme-cactus-plus
 github.com/NormandErwan/Blogpaper
+github.com/nthnbch/hugo-fraktur-theme
 github.com/ntk148v/hugo-cuisine-book
 github.com/ntk148v/hugo-toigian
 github.com/ntk148v/shibui
-github.com/nthnbch/hugo-fraktur-theme
 github.com/nunocoracao/blowfish/v2
 github.com/nurlansu/hugo-sustain
 github.com/nusserstudios/tailbliss


### PR DESCRIPTION
After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

- [x] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [x] name
    - [x] license
    - [x] licenselink
    - [x] description
    - [x] homepage
    - [x] demosite (if one exists)
    - [x] tags
    - [x] features
    - [x] authors/author (depending on whether the theme has multiple or a single author)
    - [x] original (if the theme is a fork)
- [x] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [x] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [x] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)
