### PR TITLE
Add Gitlab and Codeberg stars support

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,0 +1,1 @@
+Add support for stars acros gitlab and codeberg

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,1 +1,3 @@
 Add support for stars acros gitlab and codeberg
+
+

--- a/cmd/hugothemesitebuilder/build/site/layouts/single.html
+++ b/cmd/hugothemesitebuilder/build/site/layouts/single.html
@@ -93,8 +93,17 @@
         {{ with .Params.meta.license }}
           {{ template "descriptionlist-item" (dict "label" "License" "value" . ) }}
         {{ end }}
-        {{ with .Params.githubInfo }}
-          {{ template "descriptionlist-item" (dict "label" "GitHub Stars" "value" .Stars ) }}
+        {{ with .Params.repoInfo }}
+          {{ $host := .host }}
+          {{ if eq $host "github" }}
+            {{ template "descriptionlist-item" (dict "label" "GitHub Stars" "value" .stars ) }}
+          {{ else if eq $host "gitlab" }}
+            {{ template "descriptionlist-item" (dict "label" "GitLab Stars" "value" .stars ) }}
+          {{ else if eq $host "codeberg" }}
+            {{ template "descriptionlist-item" (dict "label" "Codeberg Stars" "value" .stars ) }}
+          {{ else }}
+            {{ template "descriptionlist-item" (dict "label" "Repository Stars" "value" .stars ) }}
+          {{ end }}
         {{ end }}
         {{ with .Params.hugoVersion.min }}
           {{ template "descriptionlist-item" (dict "label" "Minimum Hugo Version" "value" . ) }}

--- a/pkg/buildcmd/build.go
+++ b/pkg/buildcmd/build.go
@@ -209,7 +209,7 @@ type buildClient struct {
 
 	// Loaded from GitHub
 	ghReposInit sync.Once
-	ghRepos     map[string]client.GitHubRepo
+	ghRepos     map[string]client.RepoInfo
 	maxStars    int
 }
 
@@ -229,22 +229,25 @@ func (c *buildClient) err(err error) {
 
 func (c *buildClient) initGhRepos(cleanCache bool) {
 	c.ghReposInit.Do(func() {
-		ghRepos, err := c.GetGitHubRepos(c.mmap, cleanCache)
+		repos, err := c.GetRepos(c.mmap, cleanCache)
 		client.CheckErr(err)
 		maxStars := 0
-		for _, ghRepo := range ghRepos {
-			if ghRepo.Stars > maxStars {
-				maxStars = ghRepo.Stars
+		for _, repo := range repos {
+			if repo.Stars > maxStars {
+				maxStars = repo.Stars
 			}
 		}
 		c.maxStars = maxStars
-		c.ghRepos = ghRepos
+		c.ghRepos = repos
 	})
 }
 
 func (c *buildClient) getGitHubRepo(path string) client.GitHubRepo {
+	// kept for backward compatibility
 	c.initGhRepos(false)
-	return c.ghRepos[path]
+	// convert RepoInfo to GitHubRepo where possible
+	ri := c.ghRepos[path]
+	return client.GitHubRepo{HTMLURL: ri.HTMLURL, Stars: ri.Stars, CreatedAt: ri.CreatedAt}
 }
 
 func (c *buildClient) writeThemesContent() error {
@@ -362,7 +365,11 @@ func (c *buildClient) writeThemeContent(k string, m client.Module) error {
 		m:             m,
 		name:          themeName,
 		readMeContent: getReadMeContent(),
-		ghRepo:        c.getGitHubRepo(m.Path),
+	}
+
+	// attach repo info if available
+	if ri, ok := c.ghRepos[m.Path]; ok {
+		thm.repo = ri
 	}
 
 	thm.calculateWeight(c.maxStars)
@@ -431,8 +438,8 @@ type theme struct {
 	m    client.Module
 	name string
 
-	// Set when hosted on GitHub.
-	ghRepo client.GitHubRepo
+	// Repo info (GitHub, GitLab, Codeberg...)
+	repo client.RepoInfo
 
 	readMeContent string
 
@@ -463,7 +470,7 @@ var (
 func (t *theme) calculateWeight(maxStars int) {
 	const maxMaxStars = 3000
 	t.weight = min(maxStars, maxMaxStars) + 500
-	t.weight -= min(t.ghRepo.Stars, maxMaxStars)
+	t.weight -= min(t.repo.Stars, maxMaxStars)
 
 	boostRecent := func(age, threshold time.Duration, boost int) {
 		if age < threshold {
@@ -477,14 +484,11 @@ func (t *theme) calculateWeight(maxStars int) {
 		boostRecent(time.Since(t.m.Time), (1 * d30), 40)
 	}
 
-	if !t.ghRepo.IsZero() {
+	if !t.repo.CreatedAt.IsZero() {
 		// Boost themes created recently.
-		boostRecent(time.Since(t.ghRepo.CreatedAt), (1 * d30), 100)
-		boostRecent(time.Since(t.ghRepo.CreatedAt), (1 * d1y), 50)
-		// Pull themes created within the last week the top.
-		// Note that we currently only have that information for themes
-		// hosted on GitHub.
-		boostRecent(time.Since(t.ghRepo.CreatedAt), (1 * d7), 50000)
+		boostRecent(time.Since(t.repo.CreatedAt), (1 * d30), 100)
+		boostRecent(time.Since(t.repo.CreatedAt), (1 * d1y), 50)
+		boostRecent(time.Since(t.repo.CreatedAt), (1 * d7), 50000)
 	}
 
 	// Boost themes with a Hugo version indicator set that covers.
@@ -516,9 +520,11 @@ func (t *theme) toFrontMatter() map[string]interface{} {
 
 	var htmlURL string
 	var starCount int
-	if !t.ghRepo.IsZero() {
-		htmlURL = t.ghRepo.HTMLURL
-		starCount = t.ghRepo.Stars
+	var repoHost string
+	if t.repo.HTMLURL != "" {
+		htmlURL = t.repo.HTMLURL
+		starCount = t.repo.Stars
+		repoHost = t.repo.Host
 	} else {
 		// Gitlab etc., assume the path is the base of the URL.
 		htmlURL = fmt.Sprintf("https://%s", t.m.PathRepo())
@@ -552,7 +558,7 @@ func (t *theme) toFrontMatter() map[string]interface{} {
 		"modulePath":    t.m.Path,
 		"htmlURL":       htmlURL,
 		"meta":          t.m.Meta,
-		"githubInfo":    t.ghRepo,
+		"repoInfo":      map[string]interface{}{"host": repoHost, "html_url": htmlURL, "stars": starCount, "created_at": t.repo.CreatedAt},
 		"themeWarnings": t.themeWarnings,
 		"tags":          tags,
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -488,14 +488,30 @@ func (c *Client) GetRepos(mods ModulesMap, cleanCache bool) (map[string]RepoInfo
 	defer c.TimeTrack(time.Now(), "Got repos")
 
 	repos := make(map[string]RepoInfo)
+
+	// First, load cached GitHub info where available.
+	ghMap, err := c.GetGitHubRepos(mods, cleanCache)
+	if err != nil {
+		c.Logf("warning: failed to load GitHub cache: %s", err)
+	}
+
 	for _, m := range mods {
-		// try GitHub
+		// GitHub: prefer cached value from ghMap. Try both exact path and path without version (/vN).
 		if strings.HasPrefix(m.Path, "github.com") {
+			if gh, ok := ghMap[m.Path]; ok {
+				repos[m.Path] = RepoInfo{Host: "github", HTMLURL: gh.HTMLURL, Stars: gh.Stars, CreatedAt: gh.CreatedAt}
+				continue
+			}
+			if gh, ok := ghMap[m.PathWithoutVersion()]; ok {
+				repos[m.Path] = RepoInfo{Host: "github", HTMLURL: gh.HTMLURL, Stars: gh.Stars, CreatedAt: gh.CreatedAt}
+				continue
+			}
+
+			// Fallback to live fetch
 			gr, err := c.fetchGitHubRepo(m)
 			if err != nil {
 				c.Logf("warning: failed GitHub lookup for %s: %s", m.Path, err)
-				// continue, but put zero RepoInfo
-				repos[m.Path] = RepoInfo{Host: "github"}
+				repos[m.Path] = RepoInfo{Host: "github", HTMLURL: fmt.Sprintf("https://%s", m.PathRepo())}
 				continue
 			}
 			repos[m.Path] = RepoInfo{Host: "github", HTMLURL: gr.HTMLURL, Stars: gr.Stars, CreatedAt: gr.CreatedAt}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -472,3 +472,174 @@ func doGitHubRequest(req *http.Request, v interface{}) error {
 
 	return json.NewDecoder(resp.Body).Decode(v)
 }
+
+// RepoInfo is a generic representation of a repository on a host
+// used for front matter and display purposes.
+type RepoInfo struct {
+	Host      string    `json:"host"`
+	HTMLURL   string    `json:"html_url"`
+	Stars     int       `json:"stars"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// GetRepos will fetch repository information for known hosts (GitHub, GitLab, Codeberg)
+// and return a map keyed by module path.
+func (c *Client) GetRepos(mods ModulesMap, cleanCache bool) (map[string]RepoInfo, error) {
+	c.Logf("Get repos (GitHub/GitLab/Codeberg)")
+	defer c.TimeTrack(time.Now(), "Got repos")
+
+	repos := make(map[string]RepoInfo)
+	for _, m := range mods {
+		// try GitHub
+		if strings.HasPrefix(m.Path, "github.com") {
+			gr, err := c.fetchGitHubRepo(m)
+			if err != nil {
+				c.Logf("warning: failed GitHub lookup for %s: %s", m.Path, err)
+				// continue, but put zero RepoInfo
+				repos[m.Path] = RepoInfo{Host: "github"}
+				continue
+			}
+			repos[m.Path] = RepoInfo{Host: "github", HTMLURL: gr.HTMLURL, Stars: gr.Stars, CreatedAt: gr.CreatedAt}
+			continue
+		}
+
+		// GitLab
+		if strings.HasPrefix(m.Path, "gitlab.com") {
+			rif, err := c.fetchGitLabRepo(m)
+			if err != nil {
+				c.Logf("warning: failed GitLab lookup for %s: %s", m.Path, err)
+				repos[m.Path] = RepoInfo{Host: "gitlab", HTMLURL: fmt.Sprintf("https://%s", m.PathRepo())}
+				continue
+			}
+			repos[m.Path] = rif
+			continue
+		}
+
+		// Codeberg
+		if strings.HasPrefix(m.Path, "codeberg.org") {
+			rif, err := c.fetchCodebergRepo(m)
+			if err != nil {
+				c.Logf("warning: failed Codeberg lookup for %s: %s", m.Path, err)
+				repos[m.Path] = RepoInfo{Host: "codeberg", HTMLURL: fmt.Sprintf("https://%s", m.PathRepo())}
+				continue
+			}
+			repos[m.Path] = rif
+			continue
+		}
+
+		// default: unknown host, provide basic URL
+		repos[m.Path] = RepoInfo{Host: "unknown", HTMLURL: fmt.Sprintf("https://%s", m.PathRepo())}
+	}
+
+	return repos, nil
+}
+
+func (c *Client) fetchGitLabRepo(m Module) (RepoInfo, error) {
+	var ri RepoInfo
+	const gitlabdotcom = "gitlab.com"
+
+	if !strings.HasPrefix(m.Path, gitlabdotcom) {
+		return ri, nil
+	}
+
+	// GitLab API: projects/:id where id is URL-encoded path (owner%2Frepo)
+	repoPath := strings.TrimPrefix(m.PathRepo(), gitlabdotcom+"/")
+	apiURL := "https://gitlab.com/api/v4/projects/" + url.PathEscape(repoPath)
+
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return ri, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return ri, err
+	}
+	defer resp.Body.Close()
+
+	if isError(resp) {
+		b, _ := ioutil.ReadAll(resp.Body)
+		return ri, fmt.Errorf("GitLab lookup failed: %s", string(b))
+	}
+
+	var payload struct {
+		Stars     int    `json:"star_count"`
+		WebURL    string `json:"web_url"`
+		CreatedAt string `json:"created_at"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return ri, err
+	}
+
+	var created time.Time
+	if payload.CreatedAt != "" {
+		if t, err := time.Parse(time.RFC3339, payload.CreatedAt); err == nil {
+			created = t
+		}
+	}
+
+	ri = RepoInfo{Host: "gitlab", HTMLURL: payload.WebURL, Stars: payload.Stars, CreatedAt: created}
+	return ri, nil
+}
+
+func (c *Client) fetchCodebergRepo(m Module) (RepoInfo, error) {
+	var ri RepoInfo
+	const codeberg = "codeberg.org"
+
+	if !strings.HasPrefix(m.Path, codeberg) {
+		return ri, nil
+	}
+
+	// Codeberg (Gitea) API: /api/v1/repos/{owner}/{repo}
+	repoPath := strings.TrimPrefix(m.PathRepo(), codeberg+"/")
+	apiURL := "https://codeberg.org/api/v1/repos/" + repoPath
+
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return ri, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return ri, err
+	}
+	defer resp.Body.Close()
+
+	if isError(resp) {
+		b, _ := ioutil.ReadAll(resp.Body)
+		return ri, fmt.Errorf("Codeberg lookup failed: %s", string(b))
+	}
+
+	var payload map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return ri, err
+	}
+
+	// Try common fields
+	stars := 0
+	if v, ok := payload["stargazers_count"]; ok {
+		if f, ok := v.(float64); ok {
+			stars = int(f)
+		}
+	}
+	if stars == 0 {
+		if v, ok := payload["watchers_count"]; ok {
+			if f, ok := v.(float64); ok {
+				stars = int(f)
+			}
+		}
+	}
+
+	html := "https://" + m.PathRepo()
+	created := time.Time{}
+	if v, ok := payload["created_at"]; ok {
+		if s, ok := v.(string); ok && s != "" {
+			if t, err := time.Parse(time.RFC3339, s); err == nil {
+				created = t
+			}
+		}
+	}
+
+	ri = RepoInfo{Host: "codeberg", HTMLURL: html, Stars: stars, CreatedAt: created}
+	return ri, nil
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -218,7 +218,7 @@ func (c *Client) CreateThemesConfig() error {
 				"noMounts":      true,
 			})
 		}
-		}
+	}
 	if err := scanner.Err(); err != nil {
 		return err
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -218,8 +218,7 @@ func (c *Client) CreateThemesConfig() error {
 				"noMounts":      true,
 			})
 		}
-	}
-
+		}
 	if err := scanner.Err(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds support for displaying GitLab and Codeberg star counts in the Hugo Themes Site Builder.

This PR extends the existing GitHub stars integration, so themes hosted on GitLab or Codeberg can also show their star counts on the theme's website.
It follows the same structure and logic as the GitHub implementation, keeping the code consistent and easy to maintain.