### PR TITLE
Add arts-link/ryder theme

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -43,6 +43,7 @@ github.com/apvarun/digital-garden-hugo-theme
 github.com/apvarun/showcase-hugo-theme
 github.com/apvarun/showfolio-hugo-theme
 github.com/ArkhamCookie/moonwalk-hugo
+github.com/arts-link/ryder
 github.com/asurbernardo/amperage
 github.com/athul/archie
 github.com/austingebauer/devise


### PR DESCRIPTION
Adds the `ryder` Hugo theme.

Repo: https://github.com/arts-link/ryder
Demo: https://arts-link.github.io/ryder
Latest release: v0.2.3