### PR TITLE
Add colomr-v1 theme

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -91,6 +91,7 @@ github.com/cncf/dot-org-hugo-theme
 github.com/cntrump/hugo-notepadium
 github.com/coderzh/hugo-pacman-theme
 github.com/colinwilson/lotusdocs
+github.com/colomr-dev/colomr-v1-theme
 github.com/colorchestra/smol
 github.com/coolapso/hugo-theme-hello-4s3ti
 github.com/coolapso/hugo-theme-terminalcv


### PR DESCRIPTION
## Add colomr-v1

A personal portfolio theme built with Material Design 3.

**Repository:** https://github.com/colomr-dev/colomr-v1-theme
**Demo:** https://colomr.pm
**Author:** Francisco Colomer

### Features
- Dark/Light mode toggle (dark by default)
- Cover images with configurable overlay effects (glass, vignette, shadow, highlight)
- Notion-style block system (text, cards, timeline, contact)
- Provider tabs with badge grid
- Material Symbols + Font Awesome icons
- Responsive navigation
- SCSS with MD3 design tokens
- GPL-3.0 license

### Checklist
- [x] `theme.toml` with required metadata
- [x] `LICENSE` (GPL-3.0)
- [x] `exampleSite/` with demo content
- [x] `images/screenshot.png` (1500x1000+) and `images/tn.png` (900x600+)
- [x] `README.md` with installation instructions
- [x] Hugo Extended >= 0.120.0