### PR TITLE
fix: change ananke theme paths to organisation path

### DIFF
--- a/cmd/hugothemesitebuilder/build/cache/githubrepos.json
+++ b/cmd/hugothemesitebuilder/build/cache/githubrepos.json
@@ -4499,13 +4499,13 @@
     "html_url": "https://github.com/the2ne/hugo-frais",
     "stargazers_count": 9
   },
-  "github.com/theNewDynamic/gohugo-theme-ananke/v2": {
+  "github.com/gohugo-ananke/theme/v2": {
     "id": 87873787,
     "created_at": "2017-04-11T01:24:05Z",
     "updated_at": "2026-04-06T09:40:32Z",
     "name": "gohugo-theme-ananke",
     "description": "Ananke: A theme for Hugo Sites",
-    "html_url": "https://github.com/theNewDynamic/gohugo-theme-ananke",
+    "html_url": "https://github.com/gohugo-ananke/theme",
     "stargazers_count": 1364
   },
   "github.com/thegeeklab/hugo-geekblog": {

--- a/cmd/hugothemesitebuilder/build/cache/githubrepos.json
+++ b/cmd/hugothemesitebuilder/build/cache/githubrepos.json
@@ -4499,13 +4499,13 @@
     "html_url": "https://github.com/the2ne/hugo-frais",
     "stargazers_count": 9
   },
-  "github.com/gohugo-ananke/theme/v2": {
+  "github.com/gohugo-ananke/ananke/v2": {
     "id": 87873787,
     "created_at": "2017-04-11T01:24:05Z",
     "updated_at": "2026-04-06T09:40:32Z",
     "name": "gohugo-theme-ananke",
     "description": "Ananke: A theme for Hugo Sites",
-    "html_url": "https://github.com/gohugo-ananke/theme",
+    "html_url": "https://github.com/gohugo-ananke/ananke",
     "stargazers_count": 1364
   },
   "github.com/thegeeklab/hugo-geekblog": {

--- a/cmd/hugothemesitebuilder/build/config.json
+++ b/cmd/hugothemesitebuilder/build/config.json
@@ -2954,7 +2954,7 @@
         "ignoreConfig": true,
         "ignoreImports": true,
         "noMounts": true,
-        "path": "github.com/theNewDynamic/gohugo-theme-ananke/v2"
+        "path": "github.com/gohugo-ananke/theme/v2"
       },
       {
         "ignoreConfig": true,

--- a/cmd/hugothemesitebuilder/build/config.json
+++ b/cmd/hugothemesitebuilder/build/config.json
@@ -2954,7 +2954,7 @@
         "ignoreConfig": true,
         "ignoreImports": true,
         "noMounts": true,
-        "path": "github.com/gohugo-ananke/theme/v2"
+        "path": "github.com/gohugo-ananke/ananke/v2"
       },
       {
         "ignoreConfig": true,

--- a/cmd/hugothemesitebuilder/build/go.mod
+++ b/cmd/hugothemesitebuilder/build/go.mod
@@ -503,7 +503,7 @@ require (
 	github.com/tcgriffith/hugo-owaraiclub v0.0.0-20191105071036-a25aabbb1d0f // indirect
 	github.com/techbarrack/terminal-hugo-theme v0.0.0-20240611081157-ecce8013f3b7 // indirect
 	github.com/the2ne/hugo-frais v0.0.0-20200104180115-f6f23a885a7a // indirect
-	github.com/gohugo-ananke/theme/v2 v2.12.1 // indirect
+	github.com/gohugo-ananke/ananke/v2 v2.12.1 // indirect
 	github.com/thegeeklab/hugo-geekblog v4.0.0+incompatible // indirect
 	github.com/thegeeklab/hugo-geekdoc v3.0.0+incompatible // indirect
 	github.com/thingsym/hugo-theme-techdoc v1.1.0 // indirect

--- a/cmd/hugothemesitebuilder/build/go.mod
+++ b/cmd/hugothemesitebuilder/build/go.mod
@@ -503,7 +503,7 @@ require (
 	github.com/tcgriffith/hugo-owaraiclub v0.0.0-20191105071036-a25aabbb1d0f // indirect
 	github.com/techbarrack/terminal-hugo-theme v0.0.0-20240611081157-ecce8013f3b7 // indirect
 	github.com/the2ne/hugo-frais v0.0.0-20200104180115-f6f23a885a7a // indirect
-	github.com/theNewDynamic/gohugo-theme-ananke/v2 v2.12.1 // indirect
+	github.com/gohugo-ananke/theme/v2 v2.12.1 // indirect
 	github.com/thegeeklab/hugo-geekblog v4.0.0+incompatible // indirect
 	github.com/thegeeklab/hugo-geekdoc v3.0.0+incompatible // indirect
 	github.com/thingsym/hugo-theme-techdoc v1.1.0 // indirect

--- a/themes.txt
+++ b/themes.txt
@@ -489,7 +489,7 @@ github.com/the2ne/hugo-frais
 github.com/thegeeklab/hugo-geekblog
 github.com/thegeeklab/hugo-geekdoc
 github.com/ThemeTony/hugo-theme-tony
-github.com/theNewDynamic/gohugo-theme-ananke/v2
+github.com/gohugo-ananke/theme/v2
 github.com/thingsym/hugo-theme-techdoc
 github.com/tnwhitwell/hugo-startpage-theme
 github.com/tohn/linkshrubbery

--- a/themes.txt
+++ b/themes.txt
@@ -489,7 +489,7 @@ github.com/the2ne/hugo-frais
 github.com/thegeeklab/hugo-geekblog
 github.com/thegeeklab/hugo-geekdoc
 github.com/ThemeTony/hugo-theme-tony
-github.com/gohugo-ananke/theme/v2
+github.com/gohugo-ananke/ananke/v2
 github.com/thingsym/hugo-theme-techdoc
 github.com/tnwhitwell/hugo-startpage-theme
 github.com/tohn/linkshrubbery


### PR DESCRIPTION
The Ananke theme moved to its own organisation. This PR changes theme paths used. 
