### PR TITLE
Add theme kavu

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -473,6 +473,7 @@ github.com/StaticMania/portio-hugo
 github.com/StaticMania/roxo-hugo
 github.com/StefMa/hugo-fresh
 github.com/SteveLane/hugo-icon
+github.com/stultus/kavu
 github.com/sudorook/capsule
 github.com/SunkenPotato/black
 github.com/surajmandalcell/potato-dark


### PR DESCRIPTION
After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:
- [x] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [x] name
    - [x] license
    - [x] licenselink
    - [x] description
    - [x] homepage
    - [x] demosite (if one exists)
    - [x] tags
    - [x] features
    - [x] authors/author (depending on whether the theme has multiple or a single author)
    - [x] original (if the theme is a fork)
- [x] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [x] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [x] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)

---

## About this theme

Adds **Kavu**, a Hugo theme for digital gardens and personal knowledge bases.

- Repo: https://github.com/stultus/kavu
- Live site: https://stultus.in/notes
- Latest release: v1.1.0
- License: MIT

### Notable features
- Note maturity stages (`seeding` / `growing` / `evergreen`) via frontmatter
- Backlinks with one-line summaries
- Force-directed network graph with search, hover highlighting, and fullscreen
- Tag pages with co-occurrence-based related tags
- Wikilink-style `[[bracket]]` rendering for internal links
- Monospace, terminal-leaning aesthetic with full dark mode

### Why this is notably different from the original (per criterion 1)

Kavu has been rewritten substantially enough that very little of the original code remains. The homepage, note pages, tag system, network graph, CSS architecture, and JavaScript are all new:

- Entirely new homepage with live garden statistics, recently-tended and most-connected entry points, collapsible topic cards, a filterable and sortable note index, and random-note discovery
- New note pages with an inline metadata bar, summary subtitles, tag pills, and automatic backlinks with summaries
- New tag system with tag cloud, sortable tag pages (Recent / A-Z / Status), and co-occurrence-based related tags
- New interactive force-directed network graph: search, hover highlighting, label collision avoidance, fit-to-view, fullscreen, keyboard shortcuts
- New CSS architecture with monospace typography (JetBrains Mono / IBM Plex Mono / Fira Code), Nord-inspired palette via CSS variables, full dark mode
- Wikilink rendering, note maturity stages, and Malayalam (Manjari) font support added

The lineage is preserved for attribution: Kavu was originally forked from [paulmartins/hugo-digital-garden-theme](https://github.com/paulmartins/hugo-digital-garden-theme), itself inspired by [Maggie Appleton's website](https://maggieappleton.com/). Original-author attribution is retained in the README's Origin section, in the `[original]` block of `theme.toml`, and in the LICENSE.