### PR TITLE
Add theme inkstone

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -55,6 +55,7 @@ github.com/bect/kopi
 github.com/bep/docuapi/v2
 github.com/bep/galleriesdeluxe
 github.com/bep/gallerydeluxe
+github.com/BerBai/inkstone
 github.com/bin16/hugo-theme-island
 github.com/Binary-Eater/hugo-theme-ghci
 github.com/binbinsh/hugo-trainsh


### PR DESCRIPTION
## Adding [Inkstone](https://github.com/BerBai/inkstone)

A minimal bilingual Hugo theme for longreads. Tailwind v4 + 25 built-in shortcodes + CJK-native typography.

### Theme metadata

- **Repo**: https://github.com/BerBai/inkstone
- **License**: MIT
- **Hugo compatibility**: extended ≥ 0.128 (declared via `[module.hugoVersion]` in `hugo.toml`)
- **Tagged release**: [v0.1.0](https://github.com/BerBai/inkstone/releases/tag/v0.1.0)
- **Screenshot**: 1500×1000 (3:2)
- **Thumbnail**: 900×600 (3:2)
- **README**: bilingual (中文 / English) with absolute image URLs

### Why a new theme?

Inkstone is **not a fork**. It's an original Hugo theme designed around a specific niche the existing gallery doesn't cover well: **bilingual longreads with CJK-aware typography**.

Distinguishing features versus existing themes:

- **CJK-native reading time** — uses Hugo's CJK char-per-minute constant (501) instead of word-per-minute (213) for Chinese pages, giving accurate estimates for mixed-script content
- **`hasCJKLanguage` auto-routing** — picks the right reading-time formula per page based on detected language
- **25+ content shortcodes** — admonition, callout, gallery, video, tab, mermaid, markmap, math, image-compare, swiper, antv-g2, etc., with lazy CDN loading
- **Tailwind v4** — uses Hugo 0.128+ built-in `css.TailwindCSS`, no extra build step needed during dev
- **Bilingual i18n shipped** — full `en.toml` + `zh-cn.toml` UI string catalogs

### Submission checklist

- [x] `theme.toml` complete (name, license, licenselink, description, homepage, tags, features, [author])
- [x] `hugo.toml` declares `[module.hugoVersion]` (extended=true, min=0.128.0)
- [x] `LICENSE` is MIT (OSI approved)
- [x] `README.md` bilingual + absolute image URLs
- [x] `images/screenshot.png` 1500×1000 (3:2)
- [x] `images/tn.png` 900×600 (3:2)
- [x] Tagged semver release `v0.1.0`
- [x] `exampleSite/` ships with full demo (5 posts + shortcodes reference)
- [x] Original work (no fork)
- [x] Free / not paid

Inserted in lexicographical order between `github.com/bep/gallerydeluxe` and `github.com/bin16/hugo-theme-island`.