### PR TITLE
add theme Blueprint

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -282,6 +282,7 @@ github.com/khitezza/vortisil
 github.com/khusika/FeelIt
 github.com/kidlat2024/kidlat
 github.com/kimcc/hugo-theme-noteworthy
+github.com/Kircerta/hugo-blueprint
 github.com/kishaningithub/hugo-creative-portfolio-theme
 github.com/kishaningithub/hugo-shopping-product-catalogue-simple
 github.com/kishenarayan/drishtikon


### PR DESCRIPTION
add theme Blueprint

After reading the instructions for adding a theme, please make sure:

- [x] your theme.toml is complete
  - [x] name
  - [x] license
  - [x] licenselink
  - [x] description
  - [x] homepage
  - [x] demosite
  - [x] tags
  - [x] features
  - [x] author
  - [x] original
- [x] you're using absolute paths for images in your README
- [x] you've got appropriate thumbnail and screenshot images
- [x] your theme comes with an appropriate license

Theme repository: https://github.com/Kircerta/hugo-blueprint
Demo site: https://kircerta.github.io/hugo-blueprint/
License: MIT

Blueprint is a PaperMod-derived Hugo theme for dense technical blogs, project logs, and research notes.

Attribution:
Blueprint is derived from hugo-PaperMod by Aditya Telange. Thanks to Hugo and the Hugo authors.

AI usage disclosure:
AI assistance was used to review the contribution requirements, prepare documentation/demo content, and validate the Hugo build. The maintainer reviewed and approved the submitted theme content.
