### PR TITLE
💚 Fix CI by removing theme returning 403 Forbidden error

### DIFF
--- a/cmd/hugothemesitebuilder/build/cache/githubrepos.json
+++ b/cmd/hugothemesitebuilder/build/cache/githubrepos.json
@@ -5254,14 +5254,5 @@
     "description": "",
     "html_url": "",
     "stargazers_count": 0
-  },
-  "wangchucheng.com/hugo-eureka": {
-    "id": 0,
-    "created_at": "0001-01-01T00:00:00Z",
-    "updated_at": "0001-01-01T00:00:00Z",
-    "name": "",
-    "description": "",
-    "html_url": "",
-    "stargazers_count": 0
   }
 }

--- a/cmd/hugothemesitebuilder/build/config.json
+++ b/cmd/hugothemesitebuilder/build/config.json
@@ -3494,12 +3494,6 @@
         "ignoreConfig": true,
         "ignoreImports": true,
         "noMounts": true,
-        "path": "wangchucheng.com/hugo-eureka"
-      },
-      {
-        "ignoreConfig": true,
-        "ignoreImports": true,
-        "noMounts": true,
         "path": "github.com/demius782/demius"
       },
       {

--- a/cmd/hugothemesitebuilder/build/go.mod
+++ b/cmd/hugothemesitebuilder/build/go.mod
@@ -587,5 +587,4 @@ require (
 	gitlab.com/toryanderson/hugo-icarus v0.0.0-20200701121335-f3e99478c35b // indirect
 	gitlab.com/writeonlyhugo/writeonlyhugo-theme v0.0.0-20240502104725-cc4014d1c855 // indirect
 	go.ngs.io/hugo-primer-blog v1.0.8 // indirect
-	wangchucheng.com/hugo-eureka v0.9.3 // indirect
 )

--- a/themes.txt
+++ b/themes.txt
@@ -579,7 +579,6 @@ gitlab.com/tmuguet/hugo-split-gallery
 gitlab.com/toryanderson/hugo-icarus
 gitlab.com/VincentTam/huginn
 gitlab.com/writeonlyhugo/writeonlyhugo-theme
-wangchucheng.com/hugo-eureka
 github.com/demius782/demius
 go.ngs.io/hugo-primer-blog
 github.com/Blunix-GmbH/hugo-theme-blunix


### PR DESCRIPTION
There is a theme in the `themes.txt` file which points to a URL which returns a `403 Forbidden` error. The theme appears to be offline or blocked. It is causing the CI pipeline to break for all new builds.

This commit removes that repository from the index, and should fix the CI pipeline again for everyone. I encountered this while rebasing my own PR #697.

```
11:20:47 PM: go: wangchucheng.com/hugo-eureka@v0.9.3: unrecognized
import path "wangchucheng.com/hugo-eureka": reading
https://wangchucheng.com/hugo-eureka?go-get=1: 403 Forbidden
```