### PR TITLE
Add theme No Fate

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -378,6 +378,7 @@ github.com/nurlansu/hugo-sustain
 github.com/nusserstudios/tailbliss
 github.com/nux-li/hugo-foto-theme
 github.com/okkur/syna
+github.com/OliverObst/no-fate
 github.com/ololiuhqui/magnolia-free-hugo-theme
 github.com/olOwOlo/hugo-theme-even
 github.com/onweru/compose


### PR DESCRIPTION
After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

- [x] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [x] name
    - [x] license
    - [x] licenselink
    - [x] description
    - [x] homepage
    - [x] demosite (no independent demo site)
    - [x] tags
    - [x] features
    - [x] authors/author
    - [x] original
- [x] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [x] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [x] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)

Theme: https://github.com/OliverObst/no-fate

Latest release: https://github.com/OliverObst/no-fate/releases/tag/v0.1.0

No Fate is an independent derivative of PaperMod, with the relationship and exact provenance documented in its README and `UPSTREAM.md`. It is notably different through its explicit editorial page-mode contract, data-driven structured-record system, configurable modular homepage, archive and image-metadata behaviour, and separate clean/wild design systems.

Validation:

- `go test ./...` passes for this repository.
- `go list -m github.com/OliverObst/no-fate@latest` resolves to `v0.1.0`.
- No Fate's release CI, temporary Hugo Module and Git submodule installations, downstream overrides, accessibility, performance, link, HTML and visual-regression checks pass.
