### PR TITLE
Add theme hugo-pouet

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -184,6 +184,7 @@ github.com/goodroot/hugo-classic
 github.com/goofansu/hugo-modus
 github.com/google/docsy
 github.com/GrantBirki/dario
+github.com/GRodolphe/hugo-pouet
 github.com/guangmean/Niello
 github.com/guangzhengli/hugo-theme-ladder
 github.com/gundamew/hugo-bingo


### PR DESCRIPTION
Adds [hugo-pouet](https://github.com/GRodolphe/hugo-pouet), a bilingual (EN + FR) blog theme for technical writing and security research.

- Dark terminal aesthetic with a configurable accent color, dark and light mode
- Ctrl+K command palette with fuzzy search, hover preview cards
- View Transitions API with reduced-motion fallback
- Mermaid diagrams, Catppuccin syntax highlighting
- CVE tracker page, inline pdf.js slides viewer
- MIT license, Hugo >= 0.139 extended

The repo includes theme.toml, module hugoVersion config, README in English, and 3:2 screenshot and thumbnail images.