### PR TITLE
Update Hugo Sam Theme repository path

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -200,7 +200,6 @@ github.com/hdcdstr8fwd/foundation-theme
 github.com/HEIGE-PCloud/DoIt
 github.com/heksagonnet/piko
 github.com/heyeshuang/hugo-theme-tokiwa
-github.com/hivickylai/hugo-theme-sam
 github.com/homecat805/hugo-theme-walden
 github.com/hongtaoh/hugo-ht
 github.com/hootan09/simple-cv
@@ -506,6 +505,7 @@ github.com/urjaacharya/redgood
 github.com/vaga/hugo-theme-m10c
 github.com/victoriadrake/hugo-theme-introduction
 github.com/victoriadrake/hugo-theme-quint
+github.com/victoriadrake/hugo-theme-sam
 github.com/victoriadrake/neofeed-theme/v2
 github.com/Vimux/Binario
 github.com/vimux/blank


### PR DESCRIPTION
This PR fixes the Hugo Sam theme repository path in themes.txt after the owner's GitHub username changed.
The old path causes the Hugo Themes build to fail because it no longer matches the module path.