### PR TITLE
Changed repository url for HUGO.386 after migration

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -253,6 +253,7 @@ github.com/jimfrenette/hugo-starter
 github.com/jingplay/build-your-website
 github.com/JingWangTW/dark-theme-editor
 github.com/jmablog/hugo-clinic-notes
+github.com/jmfergeau/hugo.386
 github.com/jnjosh/internet-weblog
 github.com/joeroe/risotto
 github.com/jonathanjanssens/hugo-casper3
@@ -568,7 +569,6 @@ gitlab.com/gabmus/hugo-ficurinia
 gitlab.com/Goldmaster/goldmaster
 gitlab.com/ian-s-mcb/smigle-hugo-theme
 gitlab.com/jimchr12/hugo-minimal-black
-gitlab.com/jmfergeau/hugo.386
 gitlab.com/Kaligule/classless-blog
 gitlab.com/kskarthik/monopriv
 gitlab.com/kskarthik/resto-hugo


### PR DESCRIPTION
Migrated the theme's repo from gitlab to github as i'm now putting all my public/opensource projects there now. (Planning to remove the gitlab's repo in a few days too, once the PR is done)

After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

- [x] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [x] name
    - [x] license
    - [x] licenselink
    - [x] description
    - [x] homepage
    - [x] demosite (if one exists)
    - [x] tags
    - [x] features
    - [x] authors/author (depending on whether the theme has multiple or a single author)
    - [x] original (if the theme is a fork)
- [x] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [x] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [x] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)
