### PR TITLE
Add theme vellum

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -77,6 +77,7 @@ github.com/carsonip/hugo-theme-minos
 github.com/cathelijne/hugo-theme-huguette
 github.com/cboettig/hugo-now-ui
 github.com/cdeck3r/OneDly-Theme
+github.com/cebor/vellum
 github.com/cfrome77/hugo-theme-sky
 github.com/chaitanya4vedi/navada
 github.com/chaoming/hugo-saasify-theme


### PR DESCRIPTION
Adds [Vellum](https://github.com/cebor/vellum) — a multilingual theme that sets every page as an engineering drawing sheet: a drawn frame, a zone rail down the left edge that doubles as a section index, and a ruled title block carrying post metadata instead of a grey caption line.

- **Source:** https://github.com/cebor/vellum
- **Demo:** https://pages.stkn.org/felix/vellum
- **Licence:** MIT
- **Requires:** Hugo extended ≥ 0.158

Not a fork or a port — it was extracted from the personal blog it had been built inside, and is developed standalone.

After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

- [x] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [x] name
    - [x] license
    - [x] licenselink
    - [x] description
    - [x] homepage
    - [x] demosite (if one exists)
    - [x] tags
    - [x] features
    - [x] authors/author (depending on whether the theme has multiple or a single author)
    - [ ] original (if the theme is a fork) — n/a, not a fork
- [x] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [x] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media) — `images/screenshot.png` 1500×1000 and `images/tn.png` 900×600, both 3:2, both in the tagged `v0.1.0` release
- [x] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)