### PR TITLE
Allow tailwindcss in security.exec.allow so the site builds again

### DIFF
--- a/cmd/hugothemesitebuilder/build/site/hugo.toml
+++ b/cmd/hugothemesitebuilder/build/site/hugo.toml
@@ -8,6 +8,15 @@ _merge = "deep"
 [taxonomies]
   tag = "tags"
 
+# The shared Hugo Docs layouts run the stylesheet through css.TailwindCSS, and
+# Hugo's default security policy does not allow that binary to be executed --
+# note that the default node permissions below it already whitelist tailwindcss,
+# so only the exec list is out of step. Without this the site build fails with
+# `TAILWINDCSS: failed to transform "/css/styles.css" ... access denied`.
+[security]
+  [security.exec]
+    allow = ['^(dart-)?sass$', '^go$', '^git$', '^node$', '^postcss$', '^tailwindcss$']
+
 [module]
   [module.hugoVersion]
     min = "0.145.0"


### PR DESCRIPTION
Every deploy has failed since 2026-08-12 — production `main` included, not just deploy previews. The last green production build was 2026-08-10.

## The failure

`build.sh` gets through the theme fetch fine (`Processed 585 themes.`) and then Hugo fails while rendering the home page:

```
ERROR error building site: renderDeferred: ".../layouts/home.html:22:8":
... executing "_partials/helpers/linkcss.html" at <.RelPermalink>:
error calling RelPermalink: TAILWINDCSS: failed to transform "/css/styles.css" (text/css):
access denied: "tailwindcss" is not whitelisted in policy "security.exec.allow"
```

The shared Hugo Docs layouts run the stylesheet through `css.TailwindCSS` (`hugoDocs/layouts/baseof.html`), but `tailwindcss` is not in Hugo's default `security.exec.allow`, which resolves to:

```toml
allow = ['^(dart-)?sass$', '^go$', '^git$', '^node$', '^postcss$']
```

Worth noting: the default `security.node.permissions` in that same resolved policy **already** whitelist `tailwindcss` for `allowAddons`, `allowChildProcess` and `allowWorker`. Only the exec list is out of step, which is what makes this look like an oversight rather than a deliberate restriction.

## The change

One entry added to `security.exec.allow` in the site config.

## Verification

Built locally with Hugo `v0.165.0+extended`, the same version `netlify.toml` pins:

- **without** the change — fails with exactly the error above
- **with** the change — builds clean, and Tailwind really runs rather than being skipped: `public/css/styles.min.<hash>.css` is 124 KB and starts with `/*!tailwindcss v4.1.18 | MIT License */`

I ran the builder against a single-theme `themes.txt` to keep the loop short; the failing step is in the home page template and independent of which themes are listed.

I hit this while opening #763 and assumed at first that my own theme was at fault. Since all 61 open pull requests are blocked by the same red preview, it seemed more useful to send the fix than to wait. Happy to drop this if you would rather pin `HUGO_VERSION` back instead — I have no view on which you prefer.