### PR TITLE
Add theme hugo-theme-popular

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -320,6 +320,7 @@ github.com/maolonglong/hugo-simple
 github.com/marcanuy/simpleit-hugo-theme
 github.com/marcelorodrigo/hugo-fortyten
 github.com/MarcusVirg/forty
+github.com/Mariatta/hugo-theme-popular
 github.com/marketempower/axiom
 github.com/Masellum/hugo-theme-nostyleplease
 github.com/math-queiroz/rusty-typewriter


### PR DESCRIPTION
Adds **Popular**, a community-first theme for meetups, user groups and small
events: blog, events, organizers, speakers, venues, and a docs area for
handbooks and runbooks, all re-themeable from config.

- Repo: https://github.com/Mariatta/hugo-theme-popular
- Demo: https://popular.mariatta.ca/
- Licence: MIT
- Latest release: v0.11.0

Checked against the README's requirements:

- `theme.toml` with `name`, `license`, `licenselink`, `description`, `homepage`,
  `demosite`, `tags`, `features` and `[author]`
- `hugo.toml` declares `[module.hugoVersion]` with `min = "0.146.0"`; `extended`
  is unset, as the theme uses no SCSS
- `images/screenshot.png` is 3000×2000 and `images/tn.png` is 1200×800, both 3:2
  and above the minimum sizes
- Descriptive `README.md`, with no relative image paths
- Open source (MIT), not a fork, not paid
- Tagged releases following semver; the latest is v0.11.0
- `exampleSite` uses `https://example.com` as its baseURL
- No third-party CDNs: the theme self-hosts its icons and web fonts
