### PR TITLE
Update Roxo repository path

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -455,6 +455,7 @@ github.com/shenoydotme/hugo-goa
 github.com/siegerts/hugo-theme-basic
 github.com/sieis/re-cover
 github.com/sinetris/sine-die
+github.com/sitepins/roxo-hugo
 github.com/slashformotion/hugo-tufte
 github.com/softwareyoga/ronu-hugo-theme
 github.com/jkkNl/somestyleplease
@@ -470,7 +471,6 @@ github.com/splch/hugo-simplecss
 github.com/spookey/slick
 github.com/st-wong/hugo-spectre-pixel-theme
 github.com/StaticMania/portio-hugo
-github.com/StaticMania/roxo-hugo
 github.com/StefMa/hugo-fresh
 github.com/SteveLane/hugo-icon
 github.com/sudorook/capsule


### PR DESCRIPTION
## What changed

Update the Roxo theme entry from `github.com/StaticMania/roxo-hugo` to `github.com/sitepins/roxo-hugo` and keep it in lexicographical order.

## Why

The repository was transferred to the `sitepins` organization. The old path currently resolves to the new repository on GitHub, but the catalog's cached pseudo-version points to a commit that is no longer available through Go Modules:

```text
github.com/StaticMania/roxo-hugo@v0.0.0-20260505044651-6d4e83f48555:
invalid version: unknown revision 6d4e83f48555
```

This causes fresh Netlify Preview builds for unrelated theme submissions to fail before their new theme is processed.

## Validation

- Confirmed GitHub resolves the repository as `sitepins/roxo-hugo`.
- Confirmed `themes.txt` contains the new path in lexicographical order.
- `git diff --check` passes.
