### PR TITLE
Add theme hugo-theme-still

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -15,6 +15,7 @@ github.com/aanupam23/hugo-sugoi
 github.com/achary/engimo
 github.com/adityatelange/hugo-index
 github.com/adityatelange/hugo-PaperMod
+github.com/adrian-mo61/hugo-theme-still
 github.com/aerohub/hugo-faq-theme
 github.com/aerohub/hugo-identity-theme
 github.com/aerohub/hugo-orbit-theme


### PR DESCRIPTION
Adds **hugo-theme-still** to the Hugo themes gallery.

- Repository: https://github.com/adrian-mo61/hugo-theme-still
- Demo site: https://adrian-mo61.github.io/
- Latest release: https://github.com/adrian-mo61/hugo-theme-still/releases/tag/v0.1.0
- License: MIT

**Still** is a minimal, zero-JavaScript blog theme with serif Chinese typography on a warm paper tone. It ships full support for posts, taxonomies (tags + series collections), archives, pagination, RSS, syntax highlighting, and includes a complete exampleSite under `exampleSite/`.