### PR TITLE
Add theme OINK

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -398,6 +398,7 @@ github.com/pdevty/polymer
 github.com/peaceiris/hugo-theme-iris
 github.com/penyt/morandyt
 github.com/pfadfinder-konstanz/hugo-dpsg
+github.com/pgsty/oink
 github.com/ph-ph/chalk
 github.com/PippoRJ/hugo-refresh
 github.com/pjbakker/flexible-seo-hugo


### PR DESCRIPTION
## OINK

This PR adds [OINK](https://github.com/pgsty/oink) to the Hugo Themes catalog.

OINK is a local-first Hugo theme for engineering documentation and knowledge publishing. It provides Docs, Blog, Book, landing-page, and API-reference surfaces, together with offline search, multilingual navigation, dark mode, and print- and agent-friendly outputs. Consumer sites build with Hugo Extended alone—no Node.js, npm, PostCSS, or CDN is required.

- Website and live demo: https://oink.pgsty.com/
- Source: https://github.com/pgsty/oink
- Latest release: https://github.com/pgsty/oink/releases/tag/v1.0.0
- License: Apache-2.0
- Requires: Hugo Extended 0.160.1 or newer

OINK is derived from Docsy under the Apache-2.0 license and declares that origin in `theme.toml`. Its README documents the substantial architectural and feature differences from Docsy.

The module path `github.com/pgsty/oink` is added to `themes.txt` in lexicographical order.

## Submission checklist

- [x] `theme.toml` [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
  - [x] name
  - [x] license
  - [x] licenselink
  - [x] description
  - [x] homepage
  - [x] demosite
  - [x] tags
  - [x] features
  - [x] author
  - [x] original
- [x] The README uses [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images)
- [x] The theme has the required [thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [x] The theme has an [appropriate open-source license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)
