### PR TITLE
Add theme hugo-theme-stacknote

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -356,6 +356,7 @@ github.com/mozanunal/hugo-classless
 github.com/mrhelloboy/seven
 github.com/mrmierzejewski/hugo-theme-console
 github.com/MunifTanjim/minimo
+github.com/myimilo/hugo-theme-stacknote
 github.com/nanxiaobei/hugo-paper
 github.com/nanxstats/hugo-tanka
 github.com/naro143/hugo-coder-portfolio


### PR DESCRIPTION
## Summary

  Adds **Stacknote**, a warm editorial Hugo theme for technical notes and personal engineering blogs.

  - Repository: https://github.com/myimilo/hugo-theme-stacknote
  - Demo: https://wanglong.cv/
  - Latest release: https://github.com/myimilo/hugo-theme-stacknote/releases/tag/v1.0.2
  - Hugo Extended: 0.160.0 or newer
  - License: MIT

  The theme includes responsive image processing, full-text search, article-focused SEO, structured data, table of contents, related content, accessible navigation, and responsive
  editorial layouts.

  ## Submission checklist

  After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

  - [x] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
      - [x] name
      - [x] license
      - [x] licenselink
      - [x] description
      - [x] homepage
      - [x] demosite
      - [x] tags
      - [x] features
      - [x] author
      - [x] original — not applicable; Stacknote is an original theme, not a fork
  - [x] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
  - [x] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
  - [x] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)

  ## Validation

  The example site builds successfully with Hugo Extended using:

  ```bash
  hugo \
    --noBuildLock \
    --cleanDestinationDir \
    --panicOnWarning \
    --minify