### PR TITLE
Add hugo-deskcrew

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -553,6 +553,7 @@ github.com/wayjam/hugo-theme-fluidity
 github.com/wayjam/hugo-theme-mixedpaper
 github.com/wd/hugo-fabric
 github.com/weastur/hugo-texify2
+github.com/webmilmind1/hugo-deskcrew
 github.com/wileybaba/hugo-theme-robotico
 github.com/willfaught/paige
 github.com/WingLim/hugo-tania


### PR DESCRIPTION
Theme component that adds the DeskCrew support widget (live chat, AI answers from a knowledge base, help center) to any Hugo site. MIT, theme.toml, screenshot.png and tn.png, exampleSite, tagged v1.0.0.


