### PR TITLE
Add theme flavor

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -53,6 +53,7 @@ github.com/azmelanar/hugo-theme-pixyll
 github.com/babeneso/hugo-neso
 github.com/bake/solar-theme-hugo
 github.com/balaramadurai/hugo-travelify-theme
+github.com/baozongwi/flavor
 github.com/barklan/hugo-dead-simple
 github.com/bect/kopi
 github.com/bep/docuapi/v2


### PR DESCRIPTION
## Summary

Adds **Flavor**, a paper-light / blue-dark Hugo theme for technical blogs.

- Repository: https://github.com/baozongwi/flavor
- Demo: https://bao2ongw1.github.io
- Latest release: https://github.com/baozongwi/flavor/releases/tag/v1.1.0
- Hugo Extended: 0.146.0 or newer
- License: MIT

The theme includes dark mode, overlay search (Pagefind), table of contents, AES-256-GCM encrypted posts, and friend-link cards.

## Submission checklist

After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

- [x] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [x] name
    - [x] license
    - [x] licenselink
    - [x] description
    - [x] homepage
    - [x] demosite
    - [x] tags
    - [x] features
    - [x] author
    - [x] original — not applicable; Flavor is an original theme, not a fork
- [x] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [x] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [x] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)

## Validation

The example site builds successfully with Hugo Extended 0.163.1 using:

```bash
hugo --source exampleSite --themesDir .. --minify --panicOnWarning
```