### PR TITLE
Add theme hugo-theme-sigil

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -417,6 +417,7 @@ github.com/opera7133/Blonde
 github.com/opera7133/tella
 github.com/opera7133/vnovel
 github.com/orf/bare-hugo-theme
+github.com/ouatis/hugo-theme-sigil
 github.com/oxypteros/alpha
 github.com/pacollins/calligraphy
 github.com/panr/hugo-theme-terminal/v4


### PR DESCRIPTION
Adds [hugo-theme-sigil](https://github.com/ouatis/hugo-theme-sigil), a minimal literary blog theme: old-paper background, a strict three-color system (vermilion / ink-green / amber), IBM Plex Sans CJK with a unicode-range subsetting pipeline, Tufte-style sidenotes, full-text RSS, and a View Transitions circular-reveal dark-mode toggle.

- **Demo**: https://ouatis.com/hugo-theme-sigil/ (also builds from `exampleSite`)
- **theme.toml**: complete, MIT, includes `[original]` pointing at PaperMod
- **Media**: `images/screenshot.png` (1500×1000) and `images/tn.png` (900×600), 3:2, no device mockups
- **Root `hugo.toml`**: declares `[module.hugoVersion] min = "0.156.0"`, extended
- **README**: documents config, fonts pipeline, and — per the fork criteria — a "Why a separate theme (not a PaperMod PR)" section listing the departures (sidenotes, circular-reveal toggle, ghost-year archives, full-text RSS, font pipeline)

Thanks for maintaining the gallery!