### PR TITLE
Add theme hugo-theme-freaky

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -174,6 +174,7 @@ github.com/fourtyone11/origin-hugo-theme
 github.com/foxihd/hugo-brewm
 github.com/foxihd/hugo-foxx
 github.com/fducat18/hugo-air
+github.com/freaktopus/hugo-theme-freaky
 github.com/frjo/hugo-theme-zen/v5
 github.com/funkydan2/alpha-church
 github.com/funkydan2/hugo-kiera


### PR DESCRIPTION
## Summary

Adds freaky, a minimal, dark single-page portfolio theme with a typing animation, projects, publications, and an optional contact form.

- Repository: https://github.com/freaktopus/hugo-theme-freaky
- Demo: https://freaktopus.github.io/hugo-theme-freaky/
- Latest release: https://github.com/freaktopus/hugo-theme-freaky/releases/tag/v0.1.1
- Hugo Extended: 0.120.0 or newer
- License: MIT

The theme includes a hero with typing animation, scroll-spy navigation, projects / publications / articles / blogs sections, a backend-free contact form (drafts the message to the visitor's clipboard), an optional site-views counter, configurable design tokens, and head/body extension hooks — plain HTML/CSS/JS with no dependencies.

## Submission checklist

- your theme.toml is complete
    - name
    - license
    - licenselink
    - description
    - homepage
    - demosite
    - tags
    - features
    - author
    - original — not applicable; freaky is an original theme, not a fork
- you're using absolute paths for images in your README
- you've got appropriate thumbnail and screenshot images
- your theme comes with an appropriate license